### PR TITLE
Update html fixtures for layout tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -34,6 +34,28 @@ typed-ast = {version = ">=1.4.0,<1.5", markers = "implementation_name == \"cpyth
 wrapt = ">=1.11,<1.13"
 
 [[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "21.4.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.10.0"
 description = "Screen-scraping library"
@@ -205,6 +227,14 @@ pycodestyle = ">=2.7.0,<2.8.0"
 pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
+name = "icdiff"
+version = "2.0.4"
+description = "improved colored diff"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "identify"
 version = "2.4.8"
 description = "File identification library for Python"
@@ -239,6 +269,14 @@ zipp = ">=0.5"
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "isort"
@@ -301,6 +339,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
 name = "pathspec"
 version = "0.9.0"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -321,6 +370,29 @@ docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-
 test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pprintpp"
+version = "0.4.0"
+description = "A drop-in replacement for pprint that's actually pretty"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pre-commit"
 version = "2.15.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -336,6 +408,14 @@ nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 toml = "*"
 virtualenv = ">=20.0.8"
+
+[[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycodestyle"
@@ -378,6 +458,52 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 Markdown = ">=3.2"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.7"
+description = "Python parsing module"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pytest"
+version = "7.0.0"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+tomli = ">=1.0.0"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-icdiff"
+version = "0.5"
+description = "use icdiff for better error messages in pytest assertions"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+icdiff = "*"
+pprintpp = "*"
+pytest = "*"
 
 [[package]]
 name = "pytz"
@@ -532,7 +658,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "3e87acacc4673a82a6becb06a6a56059278c8ec7a79dd8851e3e70aed08e3239"
+content-hash = "864f1662ae4c56cb72c0b548f14709995affc109376059187f7c2cb6ddb405be"
 
 [metadata.files]
 appdirs = [
@@ -546,6 +672,14 @@ asgiref = [
 astroid = [
     {file = "astroid-2.5-py3-none-any.whl", hash = "sha256:87ae7f2398b8a0ae5638ddecf9987f081b756e0e9fc071aeebdca525671fc4dc"},
     {file = "astroid-2.5.tar.gz", hash = "sha256:b31c92f545517dcc452f284bc9c044050862fbe6d93d2b3de4a215a6b384bf0d"},
+]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 beautifulsoup4 = [
     {file = "beautifulsoup4-4.10.0-py3-none-any.whl", hash = "sha256:9a315ce70049920ea4572a4055bc4bd700c940521d36fc858205ad4fcde149bf"},
@@ -647,6 +781,9 @@ flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
     {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
 ]
+icdiff = [
+    {file = "icdiff-2.0.4.tar.gz", hash = "sha256:c72572e5ce087bc7a7748af2664764d4a805897caeefb665bdc12677fefb2212"},
+]
 identify = [
     {file = "identify-2.4.8-py2.py3-none-any.whl", hash = "sha256:a55bdd671b6063eb837af938c250ec00bba6e610454265133b0d2db7ae718d0f"},
     {file = "identify-2.4.8.tar.gz", hash = "sha256:97e839c1779f07011b84c92af183e1883d9745d532d83412cca1ca76d3808c1c"},
@@ -658,6 +795,10 @@ idna = [
 importlib-metadata = [
     {file = "importlib_metadata-4.10.1-py3-none-any.whl", hash = "sha256:899e2a40a8c4a1aec681feef45733de8a6c58f3f6a0dbed2eb6574b4387a77b6"},
     {file = "importlib_metadata-4.10.1.tar.gz", hash = "sha256:951f0d8a5b7260e9db5e41d429285b5f451e928479f19d80818878527d36e95e"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 isort = [
     {file = "isort-5.9.3-py3-none-any.whl", hash = "sha256:e17d6e2b81095c9db0a03a8025a957f334d6ea30b26f9ec70805411e5c7c81f2"},
@@ -718,6 +859,10 @@ nodeenv = [
     {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
     {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
 ]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
@@ -726,9 +871,21 @@ platformdirs = [
     {file = "platformdirs-2.4.1-py3-none-any.whl", hash = "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca"},
     {file = "platformdirs-2.4.1.tar.gz", hash = "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"},
 ]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+pprintpp = [
+    {file = "pprintpp-0.4.0-py2.py3-none-any.whl", hash = "sha256:b6b4dcdd0c0c0d75e4d7b2f21a9e933e5b2ce62b26e1a54537f9651ae5a5c01d"},
+    {file = "pprintpp-0.4.0.tar.gz", hash = "sha256:ea826108e2c7f49dc6d66c752973c3fc9749142a798d6b254e1e301cfdbc6403"},
+]
 pre-commit = [
     {file = "pre_commit-2.15.0-py2.py3-none-any.whl", hash = "sha256:a4ed01000afcb484d9eb8d504272e642c4c4099bbad3a6b27e519bd6a3e928a6"},
     {file = "pre_commit-2.15.0.tar.gz", hash = "sha256:3c25add78dbdfb6a28a651780d5c311ac40dd17f160eb3954a0c59da40a505a7"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
@@ -745,6 +902,17 @@ pylint = [
 pymdown-extensions = [
     {file = "pymdown-extensions-9.0.tar.gz", hash = "sha256:01e4bec7f4b16beaba0087a74496401cf11afd69e3a11fe95cb593e5c698ef40"},
     {file = "pymdown_extensions-9.0-py3-none-any.whl", hash = "sha256:430cc2fbb30cef2df70edac0b4f62614a6a4d2b06462e32da4ca96098b7c1dfb"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
+    {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
+]
+pytest = [
+    {file = "pytest-7.0.0-py3-none-any.whl", hash = "sha256:42901e6bd4bd4a0e533358a86e848427a49005a3256f657c5c8f8dd35ef137a9"},
+    {file = "pytest-7.0.0.tar.gz", hash = "sha256:dad48ffda394e5ad9aa3b7d7ddf339ed502e5e365b1350e0af65f4a602344b11"},
+]
+pytest-icdiff = [
+    {file = "pytest-icdiff-0.5.tar.gz", hash = "sha256:3a14097f4385665cb04330e6ae09a3dd430375f717e94482af6944470ad5f100"},
 ]
 pytz = [
     {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ detect-secrets = "~0.13"
 flake8 = "3.9.2"
 isort = "5.9.3"
 pylint = "2.6.0"
+pytest = "^7.0.0"
+pytest-icdiff = "^0.5"
 
 [tool.isort]
 known_first_party = "tbxforms"

--- a/tests/helpers/results/label_size.html
+++ b/tests/helpers/results/label_size.html
@@ -3,12 +3,12 @@
     <label for="id_name" class="tbxforms-label tbxforms-label--m">
       Name
     </label>
-    <div id="id_name_hint" class="tbxforms-hint">
+    <span id="id_name_hint" class="tbxforms-hint">
       Help text
-    </div>
+    </span>
     <input type="text" name="name"
            aria-describedby="id_name_hint"
-           class="tbxforms-input"
+           class="tbxforms-input tbxforms-input--text"
            id="id_name">
   </div>
 </form>

--- a/tests/helpers/results/legend_size.html
+++ b/tests/helpers/results/legend_size.html
@@ -6,9 +6,9 @@
         How would you like to be contacted?
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select all options that are relevant to you.
-      </div>
+      </span>
 
       <div class="tbxforms-checkboxes">
 

--- a/tests/helpers/results/override_label_size.html
+++ b/tests/helpers/results/override_label_size.html
@@ -3,12 +3,12 @@
     <label for="id_name" class="tbxforms-label tbxforms-label--l">
       Name
     </label>
-    <div id="id_name_hint" class="tbxforms-hint">
+    <span id="id_name_hint" class="tbxforms-hint">
       Help text
-    </div>
+    </span>
     <input type="text" name="name"
            aria-describedby="id_name_hint"
-           class="tbxforms-input"
+           class="tbxforms-input tbxforms-input--text"
            id="id_name">
   </div>
 </form>

--- a/tests/helpers/results/override_legend_size.html
+++ b/tests/helpers/results/override_legend_size.html
@@ -6,9 +6,9 @@
         How would you like to be contacted?
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select all options that are relevant to you.
-      </div>
+      </span>
 
       <div class="tbxforms-checkboxes">
 

--- a/tests/layout/results/buttons/attributes.html
+++ b/tests/layout/results/buttons/attributes.html
@@ -1,5 +1,4 @@
 <button name="name"
-        class="tbxforms-button"
+        class="tbxforms-button tbxforms-button--primary"
         id="id_name"
-        key="value"
-        data-module="tbxforms-button">Title</button>
+        key="value">Title</button>

--- a/tests/layout/results/buttons/css_class.html
+++ b/tests/layout/results/buttons/css_class.html
@@ -1,4 +1,3 @@
 <button name="name"
-        class="tbxforms-button extra-css-class"
-        id="id_name"
-        data-module="tbxforms-button">Title</button>
+        class="tbxforms-button tbxforms-button--primary extra-css-class"
+        id="id_name">Title</button>

--- a/tests/layout/results/buttons/css_id.html
+++ b/tests/layout/results/buttons/css_id.html
@@ -1,4 +1,3 @@
 <button name="name"
-        class="tbxforms-button"
-        id="new_id"
-        data-module="tbxforms-button">Title</button>
+        class="tbxforms-button tbxforms-button--primary"
+        id="new_id">Title</button>

--- a/tests/layout/results/buttons/disabled.html
+++ b/tests/layout/results/buttons/disabled.html
@@ -1,6 +1,5 @@
 <button name="name"
-        class="tbxforms-button"
+        class="tbxforms-button tbxforms-button--primary"
         disabled="disabled"
         id="id_name"
-        aria-disabled="true"
-        data-module="tbxforms-button">Title</button>
+        aria-disabled="true">Title</button>

--- a/tests/layout/results/buttons/primary.html
+++ b/tests/layout/results/buttons/primary.html
@@ -1,4 +1,3 @@
 <button name="name"
-          class="tbxforms-button"
-          id="id_name"
-          data-module="tbxforms-button">Title</button>
+          class="tbxforms-button tbxforms-button--primary"
+          id="id_name">Title</button>

--- a/tests/layout/results/buttons/secondary.html
+++ b/tests/layout/results/buttons/secondary.html
@@ -1,4 +1,3 @@
 <button name="name"
         class="tbxforms-button tbxforms-button--secondary"
-        id="id_name"
-        data-module="tbxforms-button">Title</button>
+        id="id_name">Title</button>

--- a/tests/layout/results/buttons/warning.html
+++ b/tests/layout/results/buttons/warning.html
@@ -1,4 +1,3 @@
 <button name="name"
         class="tbxforms-button tbxforms-button--warning"
-        id="id_name"
-        data-module="tbxforms-button">Title</button>
+        id="id_name">Title</button>

--- a/tests/layout/results/checkbox/checkbox_size.html
+++ b/tests/layout/results/checkbox/checkbox_size.html
@@ -1,9 +1,9 @@
 <form method="post">
   <div class="tbxforms-form-group" id="div_id_accept">
 
-    <div id="id_accept_hint" class="tbxforms-hint">
+    <span id="id_accept_hint" class="tbxforms-hint">
       Please read the terms of service.
-    </div>
+    </span>
 
     <div class="tbxforms-checkboxes tbxforms-checkboxes--small">
 

--- a/tests/layout/results/checkbox/initial.html
+++ b/tests/layout/results/checkbox/initial.html
@@ -1,9 +1,9 @@
 <form method="post">
   <div class="tbxforms-form-group" id="div_id_accept">
 
-    <div id="id_accept_hint" class="tbxforms-hint">
+    <span id="id_accept_hint" class="tbxforms-hint">
       Please read the terms of service.
-    </div>
+    </span>
 
     <div class="tbxforms-checkboxes">
 

--- a/tests/layout/results/checkbox/no_help_text_errors.html
+++ b/tests/layout/results/checkbox/no_help_text_errors.html
@@ -1,4 +1,17 @@
 <form method="post">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_accept" title="Jump to the 'I accept the terms of service' field">
+	    I accept the terms of service: You must accept our terms of service
+	  </a>
+	</li>
+      </ul>
+    </div>
+  </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_accept">
 
     <span id="id_accept_1_error" class="tbxforms-error-message">
@@ -9,9 +22,9 @@
 
       <div class="tbxforms-checkboxes__item">
         <input type="checkbox" name="accept"
-               aria-describedby="id_accept_1_error"
-               class="tbxforms-checkboxes__input"
-               id="id_accept">
+          aria-describedby="id_accept_1_error"
+          class="tbxforms-checkboxes__input"
+          id="id_accept">
         <label class="tbxforms-label tbxforms-checkboxes__label" for="id_accept">
           I accept the terms of service
         </label>

--- a/tests/layout/results/checkbox/validation_errors.html
+++ b/tests/layout/results/checkbox/validation_errors.html
@@ -1,21 +1,34 @@
 <form method="post">
-  <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_accept">
-
-    <div id="id_accept_hint" class="tbxforms-hint">
-      Please read the terms of service.
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_accept" title="Jump to the 'I accept the terms of service' field">
+	    I accept the terms of service: You must accept our terms of service
+	  </a>
+	</li>
+      </ul>
     </div>
+  </div>
+  <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_accept">
 
     <span id="id_accept_1_error" class="tbxforms-error-message">
       <span class="tbxforms-visually-hidden">Error:</span> You must accept our terms of service
+    </span>
+
+    <span id="id_accept_hint" class="tbxforms-hint">
+      Please read the terms of service.
     </span>
 
     <div class="tbxforms-checkboxes">
 
       <div class="tbxforms-checkboxes__item">
         <input type="checkbox" name="accept"
-               aria-describedby="id_accept_hint id_accept_1_error"
-               class="tbxforms-checkboxes__input"
-               id="id_accept">
+          aria-describedby="id_accept_hint id_accept_1_error"
+          class="tbxforms-checkboxes__input"
+          id="id_accept">
         <label class="tbxforms-label tbxforms-checkboxes__label" for="id_accept">
           I accept the terms of service
         </label>

--- a/tests/layout/results/checkboxes/checkbox_size.html
+++ b/tests/layout/results/checkboxes/checkbox_size.html
@@ -6,9 +6,9 @@
         How would you like to be contacted?
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select all options that are relevant to you.
-      </div>
+      </span>
 
       <div class="tbxforms-checkboxes tbxforms-checkboxes--small">
 

--- a/tests/layout/results/checkboxes/choices.html
+++ b/tests/layout/results/checkboxes/choices.html
@@ -6,9 +6,9 @@
         How would you like to be contacted?
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select all options that are relevant to you.
-      </div>
+      </span>
 
       <div class="tbxforms-checkboxes">
 

--- a/tests/layout/results/checkboxes/initial.html
+++ b/tests/layout/results/checkboxes/initial.html
@@ -6,9 +6,9 @@
         How would you like to be contacted?
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select all options that are relevant to you.
-      </div>
+      </span>
 
       <div class="tbxforms-checkboxes">
 

--- a/tests/layout/results/checkboxes/legend_heading.html
+++ b/tests/layout/results/checkboxes/legend_heading.html
@@ -8,9 +8,9 @@
         </h1>
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select all options that are relevant to you.
-      </div>
+      </span>
 
       <div class="tbxforms-checkboxes">
 

--- a/tests/layout/results/checkboxes/legend_size.html
+++ b/tests/layout/results/checkboxes/legend_size.html
@@ -6,9 +6,9 @@
         How would you like to be contacted?
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select all options that are relevant to you.
-      </div>
+      </span>
 
       <div class="tbxforms-checkboxes">
 

--- a/tests/layout/results/checkboxes/no_help_text_errors.html
+++ b/tests/layout/results/checkboxes/no_help_text_errors.html
@@ -1,4 +1,17 @@
 <form method="post">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_method" title="Jump to the 'How would you like to be contacted?' field">
+	    How would you like to be contacted?: Enter the ways to contact you
+	  </a>
+	</li>
+      </ul>
+    </div>
+  </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_method">
     <fieldset class="tbxforms-fieldset" aria-describedby=" id_method_1_error">
 

--- a/tests/layout/results/checkboxes/no_legend.html
+++ b/tests/layout/results/checkboxes/no_legend.html
@@ -2,9 +2,9 @@
   <div class="tbxforms-form-group" id="div_id_method">
     <fieldset class="tbxforms-fieldset" aria-describedby="id_method_hint">
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select all options that are relevant to you.
-      </div>
+      </span>
 
       <div class="tbxforms-checkboxes">
 

--- a/tests/layout/results/checkboxes/validation_errors.html
+++ b/tests/layout/results/checkboxes/validation_errors.html
@@ -1,4 +1,17 @@
 <form method="post">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_method" title="Jump to the 'How would you like to be contacted?' field">
+	    How would you like to be contacted?: Enter the ways to contact you
+	  </a>
+	</li>
+      </ul>
+    </div>
+  </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_method">
     <fieldset class="tbxforms-fieldset" aria-describedby="id_method_hint id_method_1_error">
 
@@ -6,12 +19,12 @@
         How would you like to be contacted?
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
-        Select all options that are relevant to you.
-      </div>
-
       <span id="id_method_1_error" class="tbxforms-error-message">
         <span class="tbxforms-visually-hidden">Error:</span> Enter the ways to contact you
+      </span>
+
+      <span id="id_method_hint" class="tbxforms-hint">
+        Select all options that are relevant to you.
       </span>
 
       <div class="tbxforms-checkboxes">

--- a/tests/layout/results/date_input/field_errors.html
+++ b/tests/layout/results/date_input/field_errors.html
@@ -1,14 +1,27 @@
 <form method="post">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_date" title="Jump to the 'When was your passport issued?' field">
+	    When was your passport issued?: Enter the day, month, and year.
+	  </a>
+	</li>
+      </ul>
+    </div>
+  </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_date">
     <fieldset class="tbxforms-fieldset" aria-describedby="id_date_hint id_date_1_error">
       <legend class="tbxforms-fieldset__legend">
         When was your passport issued?
       </legend>
-      <div id="id_date_hint" class="tbxforms-hint">
-        For example, 12 11 2007
-      </div>
       <span id="id_date_1_error" class="tbxforms-error-message"> <span class="tbxforms-visually-hidden">Error:</span>
-        Enter the day, month and year
+        Enter the day, month, and year.
+      </span>
+      <span id="id_date_hint" class="tbxforms-hint">
+        For example, 12 11 2007
       </span>
       <div class="tbxforms-date-input" id="id_date">
         <div class="tbxforms-date-input__item">
@@ -16,7 +29,7 @@
             <label class="tbxforms-label tbxforms-date-input__label" for="id_date_0">
               Day
             </label>
-            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--error tbxforms-input--width-2" id="id_date_0" name="date_0" type="text">
+            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--error tbxforms-input--text tbxforms-input--width-2" id="id_date_0" name="date_0" type="text" inputmode="numeric" pattern="[0-9]*">
           </div>
         </div>
         <div class="tbxforms-date-input__item">
@@ -24,7 +37,7 @@
             <label class="tbxforms-label tbxforms-date-input__label" for="id_date_1">
               Month
             </label>
-            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--error tbxforms-input--width-2" id="id_date_1" name="date_1" type="text">
+            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--error tbxforms-input--text tbxforms-input--width-2" id="id_date_1" name="date_1" type="text" inputmode="numeric" pattern="[0-9]*">
           </div>
         </div>
         <div class="tbxforms-date-input__item">
@@ -32,7 +45,7 @@
             <label class="tbxforms-label tbxforms-date-input__label" for="id_date_2">
               Year
             </label>
-            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--error tbxforms-input--width-4" id="id_date_2" name="date_2" type="text">
+            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--error tbxforms-input--text tbxforms-input--width-4" id="id_date_2" name="date_2" type="text" inputmode="numeric" pattern="[0-9]*">
           </div>
         </div>
       </div>

--- a/tests/layout/results/date_input/initial.html
+++ b/tests/layout/results/date_input/initial.html
@@ -4,16 +4,16 @@
       <legend class="tbxforms-fieldset__legend">
         When was your passport issued?
       </legend>
-      <div id="id_date_hint" class="tbxforms-hint">
+      <span id="id_date_hint" class="tbxforms-hint">
         For example, 12 11 2007
-      </div>
+      </span>
       <div class="tbxforms-date-input" id="id_date">
         <div class="tbxforms-date-input__item">
           <div class="tbxforms-form-group">
             <label class="tbxforms-label tbxforms-date-input__label" for="id_date_0">
               Day
             </label>
-            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--width-2" id="id_date_0" name="date_0" type="text" value="12">
+            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--text tbxforms-input--width-2" id="id_date_0" name="date_0" type="text" value="12" inputmode="numeric" pattern="[0-9]*">
           </div>
         </div>
         <div class="tbxforms-date-input__item">
@@ -21,7 +21,7 @@
             <label class="tbxforms-label tbxforms-date-input__label" for="id_date_1">
               Month
             </label>
-            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--width-2" id="id_date_1" name="date_1" type="text" value="11">
+            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--text tbxforms-input--width-2" id="id_date_1" name="date_1" type="text" value="11" inputmode="numeric" pattern="[0-9]*">
           </div>
         </div>
         <div class="tbxforms-date-input__item">
@@ -29,7 +29,7 @@
             <label class="tbxforms-label tbxforms-date-input__label" for="id_date_2">
               Year
             </label>
-            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--width-4" id="id_date_2" name="date_2" type="text" value="2007">
+            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--text tbxforms-input--width-4" id="id_date_2" name="date_2" type="text" value="2007" inputmode="numeric" pattern="[0-9]*">
           </div>
         </div>
       </div>

--- a/tests/layout/results/date_input/subfield_errors.html
+++ b/tests/layout/results/date_input/subfield_errors.html
@@ -1,26 +1,44 @@
 <form method="post">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_date" title="Jump to the 'When was your passport issued?' field">
+	    When was your passport issued?: Enter a valid date
+	  </a>
+	</li><li>
+	  <a href="#div_id_date" title="Jump to the 'When was your passport issued?' field">
+	    When was your passport issued?: Enter the year
+	  </a>
+	</li>
+      </ul>
+    </div>
+  </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_date">
     <fieldset class="tbxforms-fieldset" aria-describedby="id_date_hint id_date_1_error id_date_2_error">
       <legend class="tbxforms-fieldset__legend">
         When was your passport issued?
       </legend>
-      <div id="id_date_hint" class="tbxforms-hint">
-        For example, 12 11 2007
-      </div>
       <span id="id_date_1_error" class="tbxforms-error-message"> <span class="tbxforms-visually-hidden">Error:</span>
         Enter a valid date
       </span>
       <span id="id_date_2_error" class="tbxforms-error-message"> <span class="tbxforms-visually-hidden">Error:</span>
         Enter the year
       </span>
+      <span id="id_date_hint" class="tbxforms-hint">
+        For example, 12 11 2007
+      </span>
+
       <div class="tbxforms-date-input" id="id_date">
         <div class="tbxforms-date-input__item">
           <div class="tbxforms-form-group">
             <label class="tbxforms-label tbxforms-date-input__label" for="id_date_0">
               Day
             </label>
-            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--error tbxforms-input--width-2" id="id_date_0" name="date_0" type="text" value="a"
-                   aria-describedby="id_date_1_error">
+            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--error tbxforms-input--text tbxforms-input--width-2" id="id_date_0" name="date_0" type="text" value="a" inputmode="numeric" pattern="[0-9]*"
+              aria-describedby="id_date_1_error">
           </div>
         </div>
         <div class="tbxforms-date-input__item">
@@ -28,7 +46,7 @@
             <label class="tbxforms-label tbxforms-date-input__label" for="id_date_1">
               Month
             </label>
-            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--width-2" id="id_date_1" name="date_1" type="text" value="11">
+            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--text tbxforms-input--width-2" id="id_date_1" name="date_1" type="text" value="11" inputmode="numeric" pattern="[0-9]*">
           </div>
         </div>
         <div class="tbxforms-date-input__item">
@@ -36,8 +54,11 @@
             <label class="tbxforms-label tbxforms-date-input__label" for="id_date_2">
               Year
             </label>
-            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--error tbxforms-input--width-4" id="id_date_2" name="date_2" type="text"
-                   aria-describedby="id_date_2_error">
+            <input class="tbxforms-input tbxforms-date-input__input tbxforms-input--error tbxforms-input--text tbxforms-input--width-4" id="id_date_2" name="date_2" type="text"
+              aria-describedby="id_date_2_error"
+	      inputmode="numeric"
+	      pattern="[0-9]*"
+	    >
           </div>
         </div>
       </div>

--- a/tests/layout/results/fieldset/attributes.html
+++ b/tests/layout/results/fieldset/attributes.html
@@ -1,3 +1,3 @@
 <form method="post">
-  <fieldset class="tbxforms-fieldset" key="value"></fieldset>
+  <fieldset class="tbxforms-fieldset tbxforms-form-group" key="value"></fieldset>
 </form>

--- a/tests/layout/results/fieldset/css_class.html
+++ b/tests/layout/results/fieldset/css_class.html
@@ -1,3 +1,3 @@
 <form method="post">
-  <fieldset class="tbxforms-fieldset extra-css-class"></fieldset>
+  <fieldset class="tbxforms-fieldset tbxforms-form-group extra-css-class"></fieldset>
 </form>

--- a/tests/layout/results/fieldset/css_id.html
+++ b/tests/layout/results/fieldset/css_id.html
@@ -1,3 +1,3 @@
 <form method="post">
-  <fieldset class="tbxforms-fieldset" id="new_id"></fieldset>
+  <fieldset class="tbxforms-fieldset tbxforms-form-group" id="new_id"></fieldset>
 </form>

--- a/tests/layout/results/fieldset/layout.html
+++ b/tests/layout/results/fieldset/layout.html
@@ -1,5 +1,5 @@
 <form method="post">
-  <fieldset class="tbxforms-fieldset">
+  <fieldset class="tbxforms-fieldset tbxforms-form-group">
 
     <legend class="tbxforms-fieldset__legend">
       Contact
@@ -10,7 +10,7 @@
         Name
       </label>
       <input type="text" name="name"
-             class="tbxforms-input"
+             class="tbxforms-input tbxforms-input--text"
              id="id_name">
     </div>
 
@@ -19,7 +19,7 @@
         Email
       </label>
       <input type="text" name="email"
-             class="tbxforms-input"
+             class="tbxforms-input tbxforms-input--text"
              id="id_email">
     </div>
 

--- a/tests/layout/results/fieldset/legend_heading.html
+++ b/tests/layout/results/fieldset/legend_heading.html
@@ -1,5 +1,5 @@
 <form method="post">
-  <fieldset class="tbxforms-fieldset">
+  <fieldset class="tbxforms-fieldset tbxforms-form-group">
 
     <legend class="tbxforms-fieldset__legend">
       <h1 class="tbxforms-fieldset__heading">
@@ -12,7 +12,7 @@
         Name
       </label>
       <input type="text" name="name"
-             class="tbxforms-input"
+             class="tbxforms-input tbxforms-input--text"
              id="id_name">
     </div>
 
@@ -21,7 +21,7 @@
         Email
       </label>
       <input type="text" name="email"
-             class="tbxforms-input"
+             class="tbxforms-input tbxforms-input--text"
              id="id_email">
     </div>
 

--- a/tests/layout/results/fieldset/legend_size.html
+++ b/tests/layout/results/fieldset/legend_size.html
@@ -1,5 +1,5 @@
 <form method="post">
-  <fieldset class="tbxforms-fieldset">
+  <fieldset class="tbxforms-fieldset tbxforms-form-group">
 
     <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--l">
       Contact
@@ -10,7 +10,7 @@
         Name
       </label>
       <input type="text" name="name"
-             class="tbxforms-input"
+             class="tbxforms-input tbxforms-input--text"
              id="id_name">
     </div>
 
@@ -19,7 +19,7 @@
         Email
       </label>
       <input type="text" name="email"
-             class="tbxforms-input"
+             class="tbxforms-input tbxforms-input--text"
              id="id_email">
     </div>
 

--- a/tests/layout/results/file_upload/initial.html
+++ b/tests/layout/results/file_upload/initial.html
@@ -3,9 +3,9 @@
     <label for="id_file" class="tbxforms-label">
       Upload a file
     </label>
-    <div id="id_file_hint" class="tbxforms-hint">
+    <span id="id_file_hint" class="tbxforms-hint">
       Select the CSV file to upload.
-    </div>
+    </span>
     <input type="file" name="file"
            aria-describedby="id_file_hint"
            class="tbxforms-file-upload"

--- a/tests/layout/results/file_upload/label_heading.html
+++ b/tests/layout/results/file_upload/label_heading.html
@@ -5,9 +5,9 @@
         Upload a file
       </label>
     </h1>
-    <div id="id_file_hint" class="tbxforms-hint">
+    <span id="id_file_hint" class="tbxforms-hint">
       Select the CSV file to upload.
-    </div>
+    </span>
     <input type="file" name="file"
            aria-describedby="id_file_hint"
            class="tbxforms-file-upload"

--- a/tests/layout/results/file_upload/label_size.html
+++ b/tests/layout/results/file_upload/label_size.html
@@ -3,9 +3,9 @@
     <label for="id_file" class="tbxforms-label tbxforms-label--l">
       Upload a file
     </label>
-    <div id="id_file_hint" class="tbxforms-hint">
+    <span id="id_file_hint" class="tbxforms-hint">
       Select the CSV file to upload.
-    </div>
+    </span>
     <input type="file" name="file"
            aria-describedby="id_file_hint"
            class="tbxforms-file-upload"

--- a/tests/layout/results/file_upload/no_help_text_errors.html
+++ b/tests/layout/results/file_upload/no_help_text_errors.html
@@ -1,4 +1,17 @@
 <form method="post" enctype="multipart/form-data">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_file" title="Jump to the 'Upload a file' field">
+	    Upload a file: Select the CSV file you exported from the spreadsheet
+	  </a>
+	</li>
+      </ul>
+    </div>
+  </div>
   <div id="div_id_file" class="tbxforms-form-group tbxforms-form-group--error">
     <label for="id_file" class="tbxforms-label">
       Upload a file
@@ -7,8 +20,8 @@
       <span class="tbxforms-visually-hidden">Error:</span> Select the CSV file you exported from the spreadsheet
     </span>
     <input type="file" name="file"
-           aria-describedby="id_file_1_error"
-           class="tbxforms-file-upload tbxforms-file-upload--error"
-           id="id_file">
+      aria-describedby="id_file_1_error"
+      class="tbxforms-file-upload tbxforms-file-upload--error"
+      id="id_file">
   </div>
 </form>

--- a/tests/layout/results/file_upload/no_label.html
+++ b/tests/layout/results/file_upload/no_label.html
@@ -1,8 +1,8 @@
 <form method="post" enctype="multipart/form-data">
   <div id="div_id_file" class="tbxforms-form-group">
-    <div id="id_file_hint" class="tbxforms-hint">
+    <span id="id_file_hint" class="tbxforms-hint">
       Select the CSV file to upload.
-    </div>
+    </span>
     <input type="file" name="file"
            aria-describedby="id_file_hint"
            class="tbxforms-file-upload"

--- a/tests/layout/results/file_upload/validation_errors.html
+++ b/tests/layout/results/file_upload/validation_errors.html
@@ -1,17 +1,30 @@
 <form method="post" enctype="multipart/form-data">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_file" title="Jump to the 'Upload a file' field">
+	    Upload a file: Select the CSV file you exported from the spreadsheet
+	  </a>
+	</li>
+      </ul>
+    </div>
+  </div>
   <div id="div_id_file" class="tbxforms-form-group tbxforms-form-group--error">
     <label for="id_file" class="tbxforms-label">
       Upload a file
     </label>
-    <div id="id_file_hint" class="tbxforms-hint">
-      Select the CSV file to upload.
-    </div>
     <span id="id_file_1_error" class="tbxforms-error-message">
       <span class="tbxforms-visually-hidden">Error:</span> Select the CSV file you exported from the spreadsheet
     </span>
+    <span id="id_file_hint" class="tbxforms-hint">
+      Select the CSV file to upload.
+    </span>
     <input type="file" name="file"
-           aria-describedby="id_file_hint id_file_1_error"
-           class="tbxforms-file-upload tbxforms-file-upload--error"
-           id="id_file">
+      aria-describedby="id_file_hint id_file_1_error"
+      class="tbxforms-file-upload tbxforms-file-upload--error"
+      id="id_file">
   </div>
 </form>

--- a/tests/layout/results/radios/buttons_inline.html
+++ b/tests/layout/results/radios/buttons_inline.html
@@ -6,9 +6,9 @@
         How would you like to be contacted?
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select the most convenient way to contact you.
-      </div>
+      </span>
 
       <div class="tbxforms-radios--inline">
 

--- a/tests/layout/results/radios/buttons_small.html
+++ b/tests/layout/results/radios/buttons_small.html
@@ -6,9 +6,9 @@
         How would you like to be contacted?
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select the most convenient way to contact you.
-      </div>
+      </span>
 
       <div class="tbxforms-radios tbxforms-radios--small">
 

--- a/tests/layout/results/radios/choices.html
+++ b/tests/layout/results/radios/choices.html
@@ -6,9 +6,9 @@
         How would you like to be contacted?
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select the most convenient way to contact you.
-      </div>
+      </span>
 
       <div class="tbxforms-radios">
 

--- a/tests/layout/results/radios/initial.html
+++ b/tests/layout/results/radios/initial.html
@@ -6,9 +6,9 @@
         How would you like to be contacted?
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select the most convenient way to contact you.
-      </div>
+      </span>
 
       <div class="tbxforms-radios">
 

--- a/tests/layout/results/radios/legend_heading.html
+++ b/tests/layout/results/radios/legend_heading.html
@@ -8,9 +8,9 @@
         </h1>
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select the most convenient way to contact you.
-      </div>
+      </span>
 
       <div class="tbxforms-radios">
 

--- a/tests/layout/results/radios/legend_size.html
+++ b/tests/layout/results/radios/legend_size.html
@@ -6,9 +6,9 @@
         How would you like to be contacted?
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select the most convenient way to contact you.
-      </div>
+      </span>
 
       <div class="tbxforms-radios">
 

--- a/tests/layout/results/radios/no_help_text_errors.html
+++ b/tests/layout/results/radios/no_help_text_errors.html
@@ -1,4 +1,17 @@
 <form method="post">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_method" title="Jump to the 'How would you like to be contacted?' field">
+	    How would you like to be contacted?: Enter the best way to contact you
+	  </a>
+	</li>
+      </ul>
+    </div>
+  </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_method">
     <fieldset class="tbxforms-fieldset" aria-describedby=" id_method_1_error">
 

--- a/tests/layout/results/radios/no_legend.html
+++ b/tests/layout/results/radios/no_legend.html
@@ -2,9 +2,9 @@
   <div class="tbxforms-form-group" id="div_id_method">
     <fieldset class="tbxforms-fieldset" aria-describedby="id_method_hint">
 
-      <div id="id_method_hint" class="tbxforms-hint">
+      <span id="id_method_hint" class="tbxforms-hint">
         Select the most convenient way to contact you.
-      </div>
+      </span>
 
       <div class="tbxforms-radios">
 

--- a/tests/layout/results/radios/validation_errors.html
+++ b/tests/layout/results/radios/validation_errors.html
@@ -1,4 +1,17 @@
 <form method="post">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_method" title="Jump to the 'How would you like to be contacted?' field">
+	    How would you like to be contacted?: Enter the best way to contact you
+	  </a>
+	</li>
+      </ul>
+    </div>
+  </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_method">
     <fieldset class="tbxforms-fieldset" aria-describedby="id_method_hint id_method_1_error">
 
@@ -6,12 +19,12 @@
         How would you like to be contacted?
       </legend>
 
-      <div id="id_method_hint" class="tbxforms-hint">
-        Select the most convenient way to contact you.
-      </div>
-
       <span id="id_method_1_error" class="tbxforms-error-message">
         <span class="tbxforms-visually-hidden">Error:</span> Enter the best way to contact you
+      </span>
+
+      <span id="id_method_hint" class="tbxforms-hint">
+        Select the most convenient way to contact you.
       </span>
 
       <div class="tbxforms-radios">

--- a/tests/layout/results/select/initial.html
+++ b/tests/layout/results/select/initial.html
@@ -4,9 +4,9 @@
       How would you like to be contacted?
     </label>
 
-    <div id="id_method_hint" class="tbxforms-hint">
+    <span id="id_method_hint" class="tbxforms-hint">
       Select the most convenient way to contact you.
-    </div>
+    </span>
 
     <select class="tbxforms-select" name="method" id="id_method" aria-describedby="id_method_hint">
       <option value="">Choose</option>

--- a/tests/layout/results/select/label_heading.html
+++ b/tests/layout/results/select/label_heading.html
@@ -6,9 +6,9 @@
       </label>
     </h1>
 
-    <div id="id_method_hint" class="tbxforms-hint">
+    <span id="id_method_hint" class="tbxforms-hint">
       Select the most convenient way to contact you.
-    </div>
+    </span>
 
     <select class="tbxforms-select" name="method" id="id_method" aria-describedby="id_method_hint">
       <option value="" selected>Choose</option>

--- a/tests/layout/results/select/label_size.html
+++ b/tests/layout/results/select/label_size.html
@@ -4,9 +4,9 @@
       How would you like to be contacted?
     </label>
 
-    <div id="id_method_hint" class="tbxforms-hint">
+    <span id="id_method_hint" class="tbxforms-hint">
       Select the most convenient way to contact you.
-    </div>
+    </span>
 
     <select class="tbxforms-select" name="method" id="id_method" aria-describedby="id_method_hint">
       <option value="" selected>Choose</option>

--- a/tests/layout/results/select/no_help_text_errors.html
+++ b/tests/layout/results/select/no_help_text_errors.html
@@ -1,4 +1,17 @@
 <form method="post">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_method" title="Jump to the 'How would you like to be contacted?' field">
+	    How would you like to be contacted?: Enter the best way to contact you
+	  </a>
+	</li>
+      </ul>
+    </div>
+  </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_method">
     <label for="id_method" class="tbxforms-label">
       How would you like to be contacted?

--- a/tests/layout/results/select/no_label.html
+++ b/tests/layout/results/select/no_label.html
@@ -1,8 +1,8 @@
 <form method="post">
   <div class="tbxforms-form-group" id="div_id_method">
-    <div id="id_method_hint" class="tbxforms-hint">
+    <span id="id_method_hint" class="tbxforms-hint">
       Select the most convenient way to contact you.
-    </div>
+    </span>
 
     <select class="tbxforms-select" name="method" id="id_method" aria-describedby="id_method_hint">
       <option value="" selected>Choose</option>

--- a/tests/layout/results/select/validation_errors.html
+++ b/tests/layout/results/select/validation_errors.html
@@ -1,15 +1,27 @@
 <form method="post">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_method" title="Jump to the 'How would you like to be contacted?' field">
+	    How would you like to be contacted?: Enter the best way to contact you
+	  </a>
+	</li>
+      </ul>
+    </div>
+  </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_method">
     <label for="id_method" class="tbxforms-label">
       How would you like to be contacted?
     </label>
 
-    <div id="id_method_hint" class="tbxforms-hint">
-      Select the most convenient way to contact you.
-    </div>
-
     <span id="id_method_1_error" class="tbxforms-error-message">
       <span class="tbxforms-visually-hidden">Error:</span> Enter the best way to contact you
+    </span>
+    <span id="id_method_hint" class="tbxforms-hint">
+      Select the most convenient way to contact you.
     </span>
 
     <select class="tbxforms-select tbxforms-input--error" name="method" id="id_method" aria-describedby="id_method_hint id_method_1_error">

--- a/tests/layout/results/text_input/initial.html
+++ b/tests/layout/results/text_input/initial.html
@@ -3,12 +3,12 @@
     <label for="id_name" class="tbxforms-label">
       Name
     </label>
-    <div id="id_name_hint" class="tbxforms-hint">
+    <span id="id_name_hint" class="tbxforms-hint">
       Help text
-    </div>
+    </span>
     <input type="text" name="name"
            aria-describedby="id_name_hint"
-           class="tbxforms-input"
+           class="tbxforms-input tbxforms-input--text"
            id="id_name"
            value="Field value">
   </div>

--- a/tests/layout/results/text_input/label_heading.html
+++ b/tests/layout/results/text_input/label_heading.html
@@ -5,12 +5,12 @@
         Name
       </label>
     </h1>
-    <div id="id_name_hint" class="tbxforms-hint">
+    <span id="id_name_hint" class="tbxforms-hint">
       Help text
-    </div>
+    </span>
     <input type="text" name="name"
            aria-describedby="id_name_hint"
-           class="tbxforms-input"
+           class="tbxforms-input tbxforms-input--text"
            id="id_name">
   </div>
 </form>

--- a/tests/layout/results/text_input/label_size.html
+++ b/tests/layout/results/text_input/label_size.html
@@ -3,12 +3,12 @@
     <label for="id_name" class="tbxforms-label tbxforms-label--l">
       Name
     </label>
-    <div id="id_name_hint" class="tbxforms-hint">
+    <span id="id_name_hint" class="tbxforms-hint">
       Help text
-    </div>
+    </span>
     <input type="text" name="name"
            aria-describedby="id_name_hint"
-           class="tbxforms-input"
+           class="tbxforms-input tbxforms-input--text"
            id="id_name">
   </div>
 </form>

--- a/tests/layout/results/text_input/no_help_text.html
+++ b/tests/layout/results/text_input/no_help_text.html
@@ -4,7 +4,7 @@
       Name
     </label>
     <input type="text" name="name"
-           class="tbxforms-input"
+           class="tbxforms-input tbxforms-input--text"
            id="id_name">
   </div>
 </form>

--- a/tests/layout/results/text_input/no_help_text_errors.html
+++ b/tests/layout/results/text_input/no_help_text_errors.html
@@ -1,4 +1,17 @@
 <form method="post">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_name" title="Jump to the 'Name' field">
+	    Name: Required error message
+	  </a>
+	</li>
+      </ul>
+    </div>
+  </div>
   <div id="div_id_name" class="tbxforms-form-group tbxforms-form-group--error">
     <label for="id_name" class="tbxforms-label">
       Name
@@ -7,8 +20,8 @@
       <span class="tbxforms-visually-hidden">Error:</span> Required error message
     </span>
     <input type="text" name="name"
-           aria-describedby="id_name_1_error"
-           class="tbxforms-input tbxforms-input--error"
-           id="id_name">
+      aria-describedby="id_name_1_error"
+      class="tbxforms-input tbxforms-input--error tbxforms-input--text"
+      id="id_name">
   </div>
 </form>

--- a/tests/layout/results/text_input/no_label.html
+++ b/tests/layout/results/text_input/no_label.html
@@ -1,11 +1,11 @@
 <form method="post">
   <div id="div_id_name" class="tbxforms-form-group">
-    <div id="id_name_hint" class="tbxforms-hint">
+    <span id="id_name_hint" class="tbxforms-hint">
       Help text
-    </div>
+    </span>
     <input type="text" name="name"
            aria-describedby="id_name_hint"
-           class="tbxforms-input"
+           class="tbxforms-input tbxforms-input--text"
            id="id_name">
   </div>
 </form>

--- a/tests/layout/results/text_input/validation_errors.html
+++ b/tests/layout/results/text_input/validation_errors.html
@@ -1,17 +1,30 @@
 <form method="post">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_name" title="Jump to the 'Name' field">
+	    Name: Required error message
+	  </a>
+	</li>
+      </ul>
+    </div>
+  </div>
   <div id="div_id_name" class="tbxforms-form-group tbxforms-form-group--error">
     <label for="id_name" class="tbxforms-label">
       Name
     </label>
-    <div id="id_name_hint" class="tbxforms-hint">
-      Help text
-    </div>
     <span id="id_name_1_error" class="tbxforms-error-message">
       <span class="tbxforms-visually-hidden">Error:</span> Required error message
     </span>
+    <span id="id_name_hint" class="tbxforms-hint">
+      Help text
+    </span>
     <input type="text" name="name"
-           aria-describedby="id_name_hint id_name_1_error"
-           class="tbxforms-input tbxforms-input--error"
-           id="id_name">
+      aria-describedby="id_name_hint id_name_1_error"
+      class="tbxforms-input tbxforms-input--error tbxforms-input--text"
+      id="id_name">
   </div>
 </form>

--- a/tests/layout/results/textarea/character_count.html
+++ b/tests/layout/results/textarea/character_count.html
@@ -4,9 +4,9 @@
       <label for="id_description" class="tbxforms-label">
         Description
       </label>
-      <div id="id_description_hint" class="tbxforms-hint">
+      <span id="id_description_hint" class="tbxforms-hint">
         Help text
-      </div>
+      </span>
       <textarea name="description"
              aria-describedby="id_description_hint id_description-info"
              class="tbxforms-textarea tbxforms-js-character-count"

--- a/tests/layout/results/textarea/initial.html
+++ b/tests/layout/results/textarea/initial.html
@@ -3,9 +3,9 @@
     <label for="id_description" class="tbxforms-label">
       Description
     </label>
-    <div id="id_description_hint" class="tbxforms-hint">
+    <span id="id_description_hint" class="tbxforms-hint">
       Help text
-    </div>
+    </span>
     <textarea name="description"
            aria-describedby="id_description_hint"
            class="tbxforms-textarea"

--- a/tests/layout/results/textarea/label_heading.html
+++ b/tests/layout/results/textarea/label_heading.html
@@ -5,9 +5,9 @@
         Description
       </label>
     </h1>
-    <div id="id_description_hint" class="tbxforms-hint">
+    <span id="id_description_hint" class="tbxforms-hint">
       Help text
-    </div>
+    </span>
     <textarea name="description"
            aria-describedby="id_description_hint"
            class="tbxforms-textarea"

--- a/tests/layout/results/textarea/label_size.html
+++ b/tests/layout/results/textarea/label_size.html
@@ -3,9 +3,9 @@
     <label for="id_description" class="tbxforms-label tbxforms-label--l">
       Description
     </label>
-    <div id="id_description_hint" class="tbxforms-hint">
+    <span id="id_description_hint" class="tbxforms-hint">
       Help text
-    </div>
+    </span>
     <textarea name="description"
            aria-describedby="id_description_hint"
            class="tbxforms-textarea"

--- a/tests/layout/results/textarea/no_help_text_errors.html
+++ b/tests/layout/results/textarea/no_help_text_errors.html
@@ -1,4 +1,17 @@
 <form method="post">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+        <li>
+          <a href="#div_id_description" title="Jump to the 'Description' field">
+            Description: Required error message
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
   <div id="div_id_description" class="tbxforms-form-group tbxforms-form-group--error">
     <label for="id_description" class="tbxforms-label">
       Description

--- a/tests/layout/results/textarea/no_label.html
+++ b/tests/layout/results/textarea/no_label.html
@@ -1,8 +1,8 @@
 <form method="post">
   <div id="div_id_description" class="tbxforms-form-group">
-    <div id="id_description_hint" class="tbxforms-hint">
+    <span id="id_description_hint" class="tbxforms-hint">
       Help text
-    </div>
+    </span>
     <textarea name="description"
            aria-describedby="id_description_hint"
            class="tbxforms-textarea"

--- a/tests/layout/results/textarea/threshold.html
+++ b/tests/layout/results/textarea/threshold.html
@@ -4,9 +4,9 @@
       <label for="id_description" class="tbxforms-label">
         Description
       </label>
-      <div id="id_description_hint" class="tbxforms-hint">
+      <span id="id_description_hint" class="tbxforms-hint">
         Help text
-      </div>
+      </span>
       <textarea name="description"
              aria-describedby="id_description_hint id_description-info"
              class="tbxforms-textarea tbxforms-js-character-count"

--- a/tests/layout/results/textarea/validation_errors.html
+++ b/tests/layout/results/textarea/validation_errors.html
@@ -1,16 +1,29 @@
 <form method="post">
+  <div aria-labelledby="error-summary-title" class="tbxforms-error-summary" role="alert" tabindex="-1">
+    <h2 class="tbxforms-error-summary__title" id="error-summary-title">
+      There is a problem with your submission
+    </h2><div class="tbxforms-error-summary__body">
+      <ul class="tbxforms-error-summary__list tbxforms-list">
+	<li>
+	  <a href="#div_id_description" title="Jump to the 'Description' field">
+	    Description: Required error message
+	  </a>
+	</li>
+      </ul>
+    </div>
+  </div>
   <div id="div_id_description" class="tbxforms-form-group tbxforms-form-group--error">
     <label for="id_description" class="tbxforms-label">
       Description
     </label>
-    <div id="id_description_hint" class="tbxforms-hint">
-      Help text
-    </div>
     <span id="id_description_1_error" class="tbxforms-error-message">
       <span class="tbxforms-visually-hidden">Error:</span> Required error message
     </span>
+    <span class="tbxforms-hint" id="id_description_hint">
+      Help text
+    </span>
     <textarea name="description"
-           aria-describedby="id_description_hint id_description_1_error"
+      aria-describedby="id_description_hint id_description_1_error"
            class="tbxforms-textarea tbxforms-input--error"
            id="id_description"
            rows="10"


### PR DESCRIPTION
Adds pytest as a dev dependency, and updates the html layout fixtures to match the html being rendered by the package.

Summary of changes:
- "hint" elements changed from div to span
- move "hint" elements below error messages where appropriate
- added missing class names, e.g. "tbxforms-input--text"
- add missing error summary elements
- add various attributes to date inputs