### PR TITLE
Add dummy setup.py for GitHub’s "used by" package detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+# We use Poetry to build this package,
+# this setup.py is only for GitHub’s "Used by" detection.
+from setuptools import setup
+
+setup(name="tbxforms")


### PR DESCRIPTION
See https://patrick.wtf/posts/til-how-to-show-dependents-packages-on-github-when-using-poetry.

Example: https://github.com/torchbox/django-pattern-library/blob/main/setup.py