### PR TITLE
Rework implementation for IE11 compatibility

### DIFF
--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -3,7 +3,7 @@
 printWidth = 80
 singleQuote = true
 quoteProps = 'consistent'
-trailingComma = 'all'
+trailingComma = 'es5'
 arrowParens = 'always'
 proseWrap = 'preserve'
 bracketSpacing = true

--- a/tbxforms/static/js/tbxforms.js
+++ b/tbxforms/static/js/tbxforms.js
@@ -1,157 +1,185 @@
 import '../sass/tbxforms.scss';
 
-class TbxForms {
-  static selector() {
-    return 'form.tbxforms';
+/**
+ * CustomEvent polyfill for IE11.
+ * https://stackoverflow.com/a/26596324/1798491
+ */
+(function () {
+  if (typeof window.CustomEvent === 'function') return false; //If not IE
+
+  function CustomEvent(event, params) {
+    params = params || { bubbles: false, cancelable: false, detail: undefined };
+    var evt = document.createEvent('CustomEvent');
+    evt.initCustomEvent(
+      event,
+      params.bubbles,
+      params.cancelable,
+      params.detail,
+    );
+    return evt;
   }
 
-  constructor(node) {
-    this.form = node;
+  CustomEvent.prototype = window.Event.prototype;
 
-    // Loop through all elements within the given form (e.g. inputs, divs, fieldsets).
-    this.form.querySelectorAll('*').forEach((formElement) => {
-      // If this element has conditional logic...
-      if (
-        formElement.dataset.conditionalFieldName &&
-        formElement.dataset.conditionalFieldValues
-      ) {
-        const container = formElement.closest('.tbxforms-form-group')
-          ? formElement.closest('.tbxforms-form-group')
-          : formElement;
-        const drivingFieldNodeList = this.form.querySelectorAll(
-          `[name="${formElement.dataset.conditionalFieldName}"]`,
+  window.CustomEvent = CustomEvent;
+})();
+
+function TbxForms(form) {
+  this.form = form;
+
+  // Loop through all elements within the given form (e.g. inputs, divs, fieldsets).
+  form.querySelectorAll('*').forEach(function (formElement) {
+    // If this element has conditional logic...
+    if (
+      formElement.dataset.conditionalFieldName &&
+      formElement.dataset.conditionalFieldValues
+    ) {
+      const container = formElement.closest('.tbxforms-form-group')
+        ? formElement.closest('.tbxforms-form-group')
+        : formElement;
+      const drivingFieldNodeList = form.querySelectorAll(
+        '[name="' + formElement.dataset.conditionalFieldName + '"]',
+      );
+      let conditionalValuesForElement;
+
+      // Try to parse the JSON containing required field mapping.
+      try {
+        conditionalValuesForElement = JSON.parse(
+          formElement.dataset.conditionalFieldValues,
         );
-        let conditionalValuesForElement;
+      } catch (e) {
+        throw 'Invalid JSON: ' + e;
+      }
 
-        // Try to parse the JSON containing required field mapping.
-        try {
-          conditionalValuesForElement = JSON.parse(
-            formElement.dataset.conditionalFieldValues,
-          );
-        } catch (e) {
-          throw 'Invalid JSON: ' + e;
-        }
+      container.classList.add('tbxforms-conditional');
 
-        container.classList.add('tbxforms-conditional');
+      if (drivingFieldNodeList.length > 1) {
+        // We're dealing with radios or checkboxes.
 
-        if (drivingFieldNodeList.length > 1) {
-          // We're dealing with radios or checkboxes.
-
-          drivingFieldNodeList.forEach((option_node) => {
-            option_node.addEventListener('change', () => {
-              if (
-                option_node.checked &&
-                conditionalValuesForElement.includes(option_node.value)
-              ) {
-                option_node.setAttribute('aria-expanded', 'true');
-                container.hidden = false;
-              } else {
-                option_node.setAttribute('aria-expanded', 'false');
-                container.hidden = true;
-              }
-            });
-
-            // Trigger above event listener to correct presentation.
-            option_node.dispatchEvent(new Event('change'));
-          });
-        } else {
-          // We're dealing with a single field.
-
-          const drivingField = drivingFieldNodeList.item(0);
-
-          drivingField.addEventListener('change', () => {
+        drivingFieldNodeList.forEach(function (option_node) {
+          option_node.addEventListener('change', function () {
             if (
-              conditionalValuesForElement.includes(drivingField.value) ||
-              conditionalValuesForElement.includes(Number(drivingField.value))
+              option_node.checked &&
+              conditionalValuesForElement.includes(option_node.value)
             ) {
-              drivingField.setAttribute('aria-expanded', 'true');
+              option_node.setAttribute('aria-expanded', 'true');
               container.hidden = false;
             } else {
-              drivingField.setAttribute('aria-expanded', 'false');
+              option_node.setAttribute('aria-expanded', 'false');
               container.hidden = true;
             }
           });
 
           // Trigger above event listener to correct presentation.
-          drivingField.dispatchEvent(new Event('change'));
-        }
-      }
-    });
-
-    // Clear any values for fields that are conditionally hidden.
-    // NB. We don't use `this.form.elements.('[hidden]')` to include divs.
-    this.form.addEventListener('submit', () => {
-      this.form.querySelectorAll('[hidden]').forEach((hiddenFormElement) => {
-        this.clearInput(hiddenFormElement);
-      });
-    });
-  }
-
-  /**
-   * Reset the value of a given input, or if we're given a container
-   * (e.g. div, fieldset, etc.) then reset the fields within the container
-   * instead.
-   */
-  clearInput(node) {
-    switch (node.tagName) {
-      case 'INPUT':
-        switch (node.type) {
-          case 'color':
-          case 'date':
-          case 'datetime-local':
-          case 'email':
-          case 'file':
-          case 'hidden':
-          case 'image':
-          case 'month':
-          case 'number':
-          case 'password':
-          case 'range':
-          case 'reset':
-          case 'search':
-          case 'tel':
-          case 'text':
-          case 'time':
-          case 'url':
-          case 'week':
-            node.value = '';
-            break;
-
-          case 'radio':
-          case 'checkbox':
-            node.checked = false;
-            break;
-
-          default:
-            console.error(
-              `Unexpected node.type '${node.type}' found while trying to clearInput.`,
-            );
-        }
-        break;
-
-      case 'TEXTAREA':
-        node.value = '';
-        break;
-
-      case 'SELECT':
-        node.selectedIndex = -1;
-        break;
-
-      // If this is a container element run again for child elements.
-      // NB. maybe a `default` case would be better here.
-      case 'DIV':
-      case 'FIELDSET':
-        node.querySelectorAll('*').forEach((formElement) => {
-          this.clearInput(formElement);
+          option_node.dispatchEvent(new CustomEvent('change'));
         });
-        break;
+      } else {
+        // We're dealing with a single field.
 
-      default:
-        console.error(
-          `Unexpected node.tagName '${node.tagName}' found while trying to clearInput.`,
-        );
+        const drivingField = drivingFieldNodeList.item(0);
+
+        drivingField.addEventListener('change', function () {
+          if (
+            conditionalValuesForElement.includes(drivingField.value) ||
+            conditionalValuesForElement.includes(Number(drivingField.value))
+          ) {
+            drivingField.setAttribute('aria-expanded', 'true');
+            container.hidden = false;
+          } else {
+            drivingField.setAttribute('aria-expanded', 'false');
+            container.hidden = true;
+          }
+        });
+
+        // Trigger above event listener to correct presentation.
+        drivingField.dispatchEvent(new CustomEvent('change'));
+      }
     }
-  }
+  });
+
+  // Clear any values for fields that are conditionally hidden.
+  // NB. We don't use `form.elements.('[hidden]')` to include divs.
+  form.addEventListener('submit', function () {
+    form.querySelectorAll('[hidden]').forEach(function (hiddenFormElement) {
+      form.clearInput(hiddenFormElement);
+    });
+  });
 }
+
+/**
+ * Reset the value of a given input, or if we're given a container
+ * (e.g. div, fieldset, etc.) then reset the fields within the container
+ * instead.
+ */
+TbxForms.prototype.clearInput = function (node) {
+  const self = this;
+
+  switch (node.tagName) {
+    case 'INPUT':
+      switch (node.type) {
+        case 'color':
+        case 'date':
+        case 'datetime-local':
+        case 'email':
+        case 'file':
+        case 'hidden':
+        case 'image':
+        case 'month':
+        case 'number':
+        case 'password':
+        case 'range':
+        case 'reset':
+        case 'search':
+        case 'tel':
+        case 'text':
+        case 'time':
+        case 'url':
+        case 'week':
+          node.value = '';
+          break;
+
+        case 'radio':
+        case 'checkbox':
+          node.checked = false;
+          break;
+
+        default:
+          console.error(
+            "Unexpected node.type '" +
+              node.type +
+              "' found while trying to clearInput.",
+          );
+      }
+      break;
+
+    case 'TEXTAREA':
+      node.value = '';
+      break;
+
+    case 'SELECT':
+      node.selectedIndex = -1;
+      break;
+
+    // If this is a container element run again for child elements.
+    // NB. maybe a `default` case would be better here.
+    case 'DIV':
+    case 'FIELDSET':
+      node.querySelectorAll('*').forEach(function (formElement) {
+        self.clearInput(formElement);
+      });
+      break;
+
+    default:
+      console.error(
+        "Unexpected node.tagName '" +
+          node.tagName +
+          "' found while trying to clearInput.",
+      );
+  }
+};
+
+TbxForms.selector = function () {
+  return 'form.tbxforms';
+};
 
 export default TbxForms;

--- a/tbxforms/static/js/tbxforms.js
+++ b/tbxforms/static/js/tbxforms.js
@@ -14,7 +14,7 @@ import '../sass/tbxforms.scss';
       event,
       params.bubbles,
       params.cancelable,
-      params.detail,
+      params.detail
     );
     return evt;
   }
@@ -38,14 +38,14 @@ function TbxForms(form) {
         ? formElement.closest('.tbxforms-form-group')
         : formElement;
       const drivingFieldNodeList = form.querySelectorAll(
-        '[name="' + formElement.dataset.conditionalFieldName + '"]',
+        '[name="' + formElement.dataset.conditionalFieldName + '"]'
       );
       let conditionalValuesForElement;
 
       // Try to parse the JSON containing required field mapping.
       try {
         conditionalValuesForElement = JSON.parse(
-          formElement.dataset.conditionalFieldValues,
+          formElement.dataset.conditionalFieldValues
         );
       } catch (e) {
         throw 'Invalid JSON: ' + e;
@@ -147,7 +147,7 @@ TbxForms.prototype.clearInput = function (node) {
           console.error(
             "Unexpected node.type '" +
               node.type +
-              "' found while trying to clearInput.",
+              "' found while trying to clearInput."
           );
       }
       break;
@@ -173,7 +173,7 @@ TbxForms.prototype.clearInput = function (node) {
       console.error(
         "Unexpected node.tagName '" +
           node.tagName +
-          "' found while trying to clearInput.",
+          "' found while trying to clearInput."
       );
   }
 };


### PR DESCRIPTION
Fixes #13. I had to:

- Rewrite the code to only use ES5 syntax (avoiding classes, arrow functions, template strings)
- Add a polyfill to dispatch the `change` events

I chose to add the polyfill directly in here because it’s relatively short. The rest of the code is technically almost identical in runtime behavior (there are much fewer changes when diffing the code with [whitespace ignored](https://github.com/torchbox/tbxforms/pull/14/files?w=1)). I had to refactor slightly to avoid referring to `this` within callbacks (different semantics between arrow functions and function expressions). Otherwise the API is the same – constructor, and `.selector` static class method.

---

I chose this approach over the added tooling because:

- Vite’s official `@vite/plugin-legacy` doesn’t support library builds – which is the only thing we really need here
- Having a separate build pipeline for legacy builds would lead to too much discrepancy between production and dev, as it’d mean a different language implementation (`esbuild` vs. `typescript` or `@babel/core`).

---

Tested by loading the code in kitsite and interacting with conditional fields.