### PR TITLE
Make sure aria-described always starts with errors, then hint, then info. Fix #11

### DIFF
--- a/tbxforms/templates/tbx/layout/checkboxes.html
+++ b/tbxforms/templates/tbx/layout/checkboxes.html
@@ -3,7 +3,7 @@
 <fieldset
     class="tbxforms-fieldset"
     {% if field.help_text or field.errors %}
-        aria-describedby="{% if field.help_text %}{{ field.auto_id }}_hint{% endif %}{% for error in field.errors %} {{ field.auto_id }}_{{ forloop.counter }}_error{% endfor %}"
+        aria-describedby="{% for error in field.errors %}{{ field.auto_id }}_{{ forloop.counter }}_error {% endfor %}{% if field.help_text %}{{ field.auto_id }}_hint{% endif %}"
     {% endif %}
 >
 

--- a/tbxforms/templates/tbx/layout/multifield.html
+++ b/tbxforms/templates/tbx/layout/multifield.html
@@ -3,7 +3,7 @@
 <fieldset
     class="tbxforms-fieldset"
     {% if field.help_text or field.errors %}
-        aria-describedby="{% if field.help_text %}{{ field.auto_id }}_hint{% endif %}{% for error in field.errors %} {{ field.auto_id }}_{{ forloop.counter }}_error{% endfor %}"
+        aria-describedby="{% for error in field.errors %}{{ field.auto_id }}_{{ forloop.counter }}_error {% endfor %}{% if field.help_text %}{{ field.auto_id }}_hint{% endif %}"
     {% endif %}
 >
 

--- a/tbxforms/templates/tbx/layout/radios.html
+++ b/tbxforms/templates/tbx/layout/radios.html
@@ -3,7 +3,7 @@
 <fieldset
     class="tbxforms-fieldset"
     {% if field.help_text or field.errors %}
-        aria-describedby="{% if field.help_text %}{{ field.auto_id }}_hint{% endif %}{% for error in field.errors %} {{ field.auto_id }}_{{ forloop.counter }}_error{% endfor %}"
+        aria-describedby="{% for error in field.errors %}{{ field.auto_id }}_{{ forloop.counter }}_error {% endfor %}{% if field.help_text %}{{ field.auto_id }}_hint{% endif %}"
     {% endif %}
 >
 

--- a/tbxforms/templatetags/tbxforms.py
+++ b/tbxforms/templatetags/tbxforms.py
@@ -231,28 +231,7 @@ class CrispyGDSFieldNode(template.Node):
                 ):
                     widget.input_type = widget.attrs.pop("input_type")
 
-                if field.help_text and not is_multivalue(field):
-                    widget.attrs["aria-describedby"] = (
-                        "%s_hint" % field.auto_id
-                    )
-
-                if (
-                    "class" in widget.attrs
-                    and "tbxforms-js-character-count" in widget.attrs["class"]
-                ):
-
-                    # The javascript that updates the span containing
-                    # character count as the user types expects the id
-                    # to end in '-info'. Anything else won't work.
-
-                    if widget.attrs["aria-describedby"]:
-                        widget.attrs["aria-describedby"] += (
-                            " %s-info" % field.auto_id
-                        )
-                    else:
-                        widget.attrs["aria-describedby"] = (
-                            "%s-info" % field.auto_id
-                        )
+                aria_describedby = []
 
                 if field.errors:
                     widget_class_name = widget.__class__.__name__
@@ -277,9 +256,6 @@ class CrispyGDSFieldNode(template.Node):
                     ]:
                         css_class += " tbxforms-file-upload--error"
 
-                    if not field.help_text:
-                        widget.attrs["aria-describedby"] = ""
-
                     for error_idx, error in enumerate(field.errors, start=1):
                         css_error_class = "%s_%d_error" % (
                             field.auto_id,
@@ -291,23 +267,27 @@ class CrispyGDSFieldNode(template.Node):
                                 error_widgets[widget_idx], "errors", None
                             ):
                                 if error in error_widgets[widget_idx].errors:
-                                    if "aria-describedby" not in widget.attrs:
-                                        widget.attrs["aria-describedby"] = ""
-
-                                    if widget.attrs["aria-describedby"]:
-                                        widget.attrs["aria-describedby"] += " "
-
-                                    widget.attrs[
-                                        "aria-describedby"
-                                    ] += css_error_class
+                                    aria_describedby.append(css_error_class)
                         else:
-                            if "aria-describedby" not in widget.attrs:
-                                widget.attrs["aria-describedby"] = ""
+                            aria_describedby.append(css_error_class)
 
-                            if widget.attrs["aria-describedby"]:
-                                widget.attrs["aria-describedby"] += " "
+                if field.help_text and not is_multivalue(field):
+                    aria_describedby.append(f"{field.auto_id}_hint")
 
-                            widget.attrs["aria-describedby"] += css_error_class
+                if (
+                    "class" in widget.attrs
+                    and "tbxforms-js-character-count" in widget.attrs["class"]
+                ):
+
+                    # The javascript that updates the span containing
+                    # character count as the user types expects the id
+                    # to end in '-info'. Anything else won't work.
+                    aria_describedby.append(f"{field.auto_id}-info")
+
+                if aria_describedby:
+                    widget.attrs["aria-describedby"] = " ".join(
+                        aria_describedby
+                    )
 
             widget.attrs["class"] = css_class
 

--- a/tests/helpers/results/error_summary.html
+++ b/tests/helpers/results/error_summary.html
@@ -19,7 +19,7 @@
       <div id="id_name_hint" class="tbxforms-hint">Help text</div>
       <span id="id_name_1_error" class="tbxforms-error-message">
       <span class="tbxforms-visually-hidden">Error:</span> Required error message</span>
-      <input type="text" name="name" class="tbxforms-input tbxforms-input--error" aria-describedby="id_name_hint id_name_1_error" id="id_name">
+      <input type="text" name="name" class="tbxforms-input tbxforms-input--error" aria-describedby="id_name_1_error id_name_hint" id="id_name">
     </div>
   </form>
 </div>

--- a/tests/layout/results/checkbox/validation_errors.html
+++ b/tests/layout/results/checkbox/validation_errors.html
@@ -26,7 +26,7 @@
 
       <div class="tbxforms-checkboxes__item">
         <input type="checkbox" name="accept"
-          aria-describedby="id_accept_hint id_accept_1_error"
+          aria-describedby="id_accept_1_error id_accept_hint"
           class="tbxforms-checkboxes__input"
           id="id_accept">
         <label class="tbxforms-label tbxforms-checkboxes__label" for="id_accept">

--- a/tests/layout/results/checkboxes/no_help_text_errors.html
+++ b/tests/layout/results/checkboxes/no_help_text_errors.html
@@ -13,7 +13,7 @@
     </div>
   </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_method">
-    <fieldset class="tbxforms-fieldset" aria-describedby=" id_method_1_error">
+    <fieldset class="tbxforms-fieldset" aria-describedby="id_method_1_error ">
 
       <legend class="tbxforms-fieldset__legend">
         How would you like to be contacted?

--- a/tests/layout/results/checkboxes/validation_errors.html
+++ b/tests/layout/results/checkboxes/validation_errors.html
@@ -13,7 +13,7 @@
     </div>
   </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_method">
-    <fieldset class="tbxforms-fieldset" aria-describedby="id_method_hint id_method_1_error">
+    <fieldset class="tbxforms-fieldset" aria-describedby="id_method_1_error id_method_hint">
 
       <legend class="tbxforms-fieldset__legend">
         How would you like to be contacted?

--- a/tests/layout/results/date_input/field_errors.html
+++ b/tests/layout/results/date_input/field_errors.html
@@ -13,7 +13,7 @@
     </div>
   </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_date">
-    <fieldset class="tbxforms-fieldset" aria-describedby="id_date_hint id_date_1_error">
+    <fieldset class="tbxforms-fieldset" aria-describedby="id_date_1_error id_date_hint">
       <legend class="tbxforms-fieldset__legend">
         When was your passport issued?
       </legend>

--- a/tests/layout/results/date_input/subfield_errors.html
+++ b/tests/layout/results/date_input/subfield_errors.html
@@ -17,7 +17,7 @@
     </div>
   </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_date">
-    <fieldset class="tbxforms-fieldset" aria-describedby="id_date_hint id_date_1_error id_date_2_error">
+    <fieldset class="tbxforms-fieldset" aria-describedby="id_date_1_error id_date_2_error id_date_hint">
       <legend class="tbxforms-fieldset__legend">
         When was your passport issued?
       </legend>

--- a/tests/layout/results/file_upload/validation_errors.html
+++ b/tests/layout/results/file_upload/validation_errors.html
@@ -23,7 +23,7 @@
       Select the CSV file to upload.
     </span>
     <input type="file" name="file"
-      aria-describedby="id_file_hint id_file_1_error"
+      aria-describedby="id_file_1_error id_file_hint"
       class="tbxforms-file-upload tbxforms-file-upload--error"
       id="id_file">
   </div>

--- a/tests/layout/results/radios/no_help_text_errors.html
+++ b/tests/layout/results/radios/no_help_text_errors.html
@@ -13,7 +13,7 @@
     </div>
   </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_method">
-    <fieldset class="tbxforms-fieldset" aria-describedby=" id_method_1_error">
+    <fieldset class="tbxforms-fieldset" aria-describedby="id_method_1_error ">
 
       <legend class="tbxforms-fieldset__legend">
         How would you like to be contacted?

--- a/tests/layout/results/radios/validation_errors.html
+++ b/tests/layout/results/radios/validation_errors.html
@@ -13,7 +13,7 @@
     </div>
   </div>
   <div class="tbxforms-form-group tbxforms-form-group--error" id="div_id_method">
-    <fieldset class="tbxforms-fieldset" aria-describedby="id_method_hint id_method_1_error">
+    <fieldset class="tbxforms-fieldset" aria-describedby="id_method_1_error id_method_hint">
 
       <legend class="tbxforms-fieldset__legend">
         How would you like to be contacted?

--- a/tests/layout/results/select/validation_errors.html
+++ b/tests/layout/results/select/validation_errors.html
@@ -24,7 +24,7 @@
       Select the most convenient way to contact you.
     </span>
 
-    <select class="tbxforms-select tbxforms-input--error" name="method" id="id_method" aria-describedby="id_method_hint id_method_1_error">
+    <select class="tbxforms-select tbxforms-input--error" name="method" id="id_method" aria-describedby="id_method_1_error id_method_hint">
       <option value="" selected>Choose</option>
       <option value="email">Email</option>
       <option value="phone">Phone</option>

--- a/tests/layout/results/text_input/validation_errors.html
+++ b/tests/layout/results/text_input/validation_errors.html
@@ -23,7 +23,7 @@
       Help text
     </span>
     <input type="text" name="name"
-      aria-describedby="id_name_hint id_name_1_error"
+      aria-describedby="id_name_1_error id_name_hint"
       class="tbxforms-input tbxforms-input--error tbxforms-input--text"
       id="id_name">
   </div>

--- a/tests/layout/results/textarea/validation_errors.html
+++ b/tests/layout/results/textarea/validation_errors.html
@@ -23,7 +23,7 @@
       Help text
     </span>
     <textarea name="description"
-      aria-describedby="id_description_hint id_description_1_error"
+      aria-describedby="id_description_1_error id_description_hint"
            class="tbxforms-textarea tbxforms-input--error"
            id="id_description"
            rows="10"


### PR DESCRIPTION
Fixes #11. The fix was more involved than I was expecting, as we set aria-describedby in a few different places. For the Python implementation, I chose to refactor `aria_describedby` to a list so we don’t have as many checks on "is it defined already" for string concatenation.

I didn’t do any manual testing for this, as the unit tests seemed excellent.