### PR TITLE
Draft: Remove safe filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,17 @@ a field's `label` and `help_text`. The defaults are set to `False`
 ```python
 TBXFORMS_ALLOW_HTML_LABEL = False
 TBXFORMS_ALLOW_HTML_HELP_TEXT = False
-TBXFORMS_ALLOW_HTML_BUTTON = False
 ```
+
+The reason why these two specifically is because `label`s are usually generated
+automatically and the `help_text`s are usually defined as static strings on model fields,
+i.e. there can be no user supplied variables.
+When enabled `tbxforms` applies `mark_safe` to these automatically,
+so there's no need to use `|safe` even in this case.
+
+Whenever a string containg html is not rendered as html never add `|safe` in a template,
+instead apply `mark_safe`, `format_html_join`, etc,
+while making sure user supplied values are never rendered as html.
 
 ### Install the NPM package
 

--- a/tbxforms/forms.py
+++ b/tbxforms/forms.py
@@ -1,7 +1,7 @@
 from django import forms as django_forms
 from django.apps import apps
 from django.conf import settings
-from django.utils.html import conditional_escape
+from django.utils.html import mark_safe
 
 from tbxforms.fields import DateInputField
 from tbxforms.helper import FormHelper
@@ -37,25 +37,12 @@ class BaseForm:
         super().__init__(*args, **kwargs)
 
         # Escape HTML within `label` and `help_text` unless it's set to allow.
-        # NB. Also see https://github.com/torchbox/tbxforms/blob/main/tbxforms/layout/buttons.py#L102  # noqa: E501
         for field_name, field in self.fields.items():
-            if all(
-                [
-                    field.label,
-                    not getattr(settings, "TBXFORMS_ALLOW_HTML_LABEL", False),
-                ]
-            ):
-                field.label = conditional_escape(field.label)
+            if getattr(settings, "TBXFORMS_ALLOW_HTML_LABEL", False):
+                field.label = mark_safe(field.label)
 
-            if all(
-                [
-                    field.help_text,
-                    not getattr(
-                        settings, "TBXFORMS_ALLOW_HTML_HELP_TEXT", False
-                    ),
-                ]
-            ):
-                field.help_text = conditional_escape(field.help_text)
+            if getattr(settings, "TBXFORMS_ALLOW_HTML_HELP_TEXT", False):
+                field.help_text = mark_safe(field.help_text)
 
 
 if "FormBuilder" in locals():

--- a/tbxforms/forms.py
+++ b/tbxforms/forms.py
@@ -7,9 +7,6 @@ from tbxforms.fields import DateInputField
 from tbxforms.helper import FormHelper
 from tbxforms.layout import Size
 
-if apps.is_installed("wagtail.contrib.forms"):
-    from wagtail.contrib.forms.forms import FormBuilder
-
 
 class BaseForm:
     @staticmethod
@@ -45,7 +42,8 @@ class BaseForm:
                 field.help_text = mark_safe(field.help_text)
 
 
-if "FormBuilder" in locals():
+if apps.is_installed("wagtail.contrib.forms"):
+    from wagtail.contrib.forms.forms import FormBuilder
 
     class BaseWagtailFormBuilder(FormBuilder):
         """

--- a/tbxforms/layout/buttons.py
+++ b/tbxforms/layout/buttons.py
@@ -1,6 +1,3 @@
-from django.conf import settings
-from django.utils.html import conditional_escape
-
 from crispy_forms.layout import BaseInput
 
 
@@ -99,16 +96,6 @@ class Button(BaseInput):
         if disabled:
             kwargs["disabled"] = "disabled"
             kwargs["aria-disabled"] = "true"
-
-        # Escape HTML within button `value`'s unless it's set to allow.
-        # NB. Also see https://github.com/torchbox/tbxforms/blob/main/tbxforms/forms.py#L39  # noqa: E501
-        if all(
-            [
-                value,
-                not getattr(settings, "TBXFORMS_ALLOW_HTML_BUTTON", False),
-            ]
-        ):
-            value = conditional_escape(value)
 
         self.css_class = css_class
         super().__init__(name, value, **kwargs)

--- a/tbxforms/templates/tbx/field.html
+++ b/tbxforms/templates/tbx/field.html
@@ -25,7 +25,7 @@
         {% if field.label and not field|is_checkbox and form_show_labels %}
             {% if label_tag %}<{{ label_tag }} class="tbxforms-label-wrapper">{% endif %}
             <label for="{{ field.id_for_label }}" class="tbxforms-label{% if label_size %} {{ label_size }}{% endif %}">
-                {{ field.label|safe }}
+                {{ field.label }}
                 {% if not field|show_as_required %} <span>{% trans "(optional)" %}</span>{% endif %}
             </label>
             {% if label_tag %}</{{ label_tag }}>{% endif %}
@@ -37,7 +37,7 @@
                 <div class="tbxforms-checkboxes__item">
                     {% crispy_tbx_field field %}
                     <label class="tbxforms-label tbxforms-checkboxes__label" for="{{ field.id_for_label }}">
-                        {{ field.label|safe }}
+                        {{ field.label }}
                     </label>
                 </div>
             </div>

--- a/tbxforms/templates/tbx/layout/baseinput.html
+++ b/tbxforms/templates/tbx/layout/baseinput.html
@@ -6,5 +6,5 @@
         class="{{ input.css_class }}"
         id="{% if input.id %}{{ input.id }}{% else %}{{ input.input_type }}-id-{{ input.name|slugify }}{% endif %}"
     {% endif %}
-    {{ input.flat_attrs|safe }}
+    {{ input.flat_attrs }}
 />

--- a/tbxforms/templates/tbx/layout/button.html
+++ b/tbxforms/templates/tbx/layout/button.html
@@ -2,5 +2,5 @@
     name="{% if input.name|wordcount > 1 %}{{ input.name|slugify }}{% else %}{{ input.name }}{% endif %}"
     class="{% if input.css_class %}{{ input.css_class }}{% else %}tbxforms-button tbxforms-button--primary{% endif %}"
     id="{% if input.id %}{{ input.id }}{% else %}id_{{ input.name|slugify }}{% endif %}"
-    {{ input.flat_attrs|safe }}
->{{ input.value|safe }}</button>
+    {{ input.flat_attrs }}
+>{{ input.value }}</button>

--- a/tbxforms/templates/tbx/layout/checkboxes.html
+++ b/tbxforms/templates/tbx/layout/checkboxes.html
@@ -10,7 +10,7 @@
     {% if field.label %}
         <legend class="tbxforms-fieldset__legend{% if legend_size %} {{ legend_size }}{% endif %}">
             {% if legend_tag %}<{{ legend_tag }} class="tbxforms-fieldset__heading">{% endif %}
-            {{ field.label|safe }}
+            {{ field.label }}
             {% if not field|show_as_required %} <span>{% trans "(optional)" %}</span>{% endif %}
             {% if legend_tag %}</{{ legend_tag }}>{% endif %}
         </legend>

--- a/tbxforms/templates/tbx/layout/div.html
+++ b/tbxforms/templates/tbx/layout/div.html
@@ -1,7 +1,7 @@
 <div
     {% if div.css_id %}id="{{ div.css_id }}"{% endif %}
     class="tbxforms-form-group{% if div.css_class %} {{ div.css_class }}{% endif %}"
-    {{ div.flat_attrs|safe }}
+    {{ div.flat_attrs }}
 >
     {{ fields|safe }}
 </div>

--- a/tbxforms/templates/tbx/layout/fieldset.html
+++ b/tbxforms/templates/tbx/layout/fieldset.html
@@ -1,13 +1,13 @@
 <fieldset
     {% if fieldset.css_id %}id="{{ fieldset.css_id }}"{% endif %}
     class="tbxforms-form-group{% if fieldset.css_class %} {{ fieldset.css_class }}{% endif %}{% if form_style %} {{ form_style }}{% endif %}"
-    {{ fieldset.flat_attrs|safe }}
+    {{ fieldset.flat_attrs }}
   >
 
     {% if legend %}
         <legend class="tbxforms-fieldset__legend{% if legend_size %} {{ legend_size }}{% endif %}">
             {% if legend_tag %}<{{ legend_tag }} class="tbxforms-fieldset__heading">{% endif %}
-            {{ legend|safe }}
+            {{ legend }}
             {% if legend_tag %}</{{ legend_tag }}>{% endif %}
         </legend>
     {% endif %}

--- a/tbxforms/templates/tbx/layout/help_text.html
+++ b/tbxforms/templates/tbx/layout/help_text.html
@@ -1,3 +1,3 @@
 {% if field.help_text %}
-    <span id="{{ field.auto_id }}_hint" class="tbxforms-hint">{{ field.help_text|safe }}</span>
+    <span id="{{ field.auto_id }}_hint" class="tbxforms-hint">{{ field.help_text }}</span>
 {% endif %}

--- a/tbxforms/templates/tbx/layout/multifield.html
+++ b/tbxforms/templates/tbx/layout/multifield.html
@@ -10,7 +10,7 @@
     {% if field.label %}
         <legend class="tbxforms-fieldset__legend{% if legend_size %} {{ legend_size }}{% endif %}">
             {% if legend_tag %}<{{ legend_tag }} class="tbxforms-fieldset__heading">{% endif %}
-            {{ field.label|safe }}
+            {{ field.label }}
             {% if not field|show_as_required %} <span>{% trans "(optional)" %}</span>{% endif %}
             {% if legend_tag %}</{{ legend_tag }}>{% endif %}
         </legend>

--- a/tbxforms/templates/tbx/layout/radios.html
+++ b/tbxforms/templates/tbx/layout/radios.html
@@ -10,7 +10,7 @@
     {% if field.label %}
         <legend class="tbxforms-fieldset__legend{% if legend_size %} {{ legend_size }}{% endif %}">
             {% if legend_tag %}<{{ legend_tag }} class="tbxforms-fieldset__heading">{% endif %}
-            {{ field.label|safe }}
+            {{ field.label }}
             {% if not field|show_as_required %} <span>{% trans "(optional)" %}</span>{% endif %}
             {% if legend_tag %}</{{ legend_tag }}>{% endif %}
         </legend>

--- a/tbxforms/templates/tbx/whole_uni_form.html
+++ b/tbxforms/templates/tbx/whole_uni_form.html
@@ -1,5 +1,5 @@
 {% if form_tag %}
-    <form {{ flat_attrs|safe }} method="{{ form_method }}" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form {{ flat_attrs }} method="{{ form_method }}" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
 {% endif %}
 
     {% if form_method|lower == 'post' and not disable_csrf %}

--- a/tbxforms/templates/tbx/whole_uni_formset.html
+++ b/tbxforms/templates/tbx/whole_uni_formset.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_tags %}
 
 {% if formset_tag %}
-    <form {{ flat_attrs|safe }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form {{ flat_attrs }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
 {% endif %}
 
     {% if formset_method|lower == 'post' and not disable_csrf %}

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -8,11 +8,11 @@ from tbxforms.layout import (
     Layout,
 )
 
+from tbxforms.forms import BaseForm as TbxFormsBaseForm
 
-class BaseForm(forms.Form):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.helper = FormHelper(self)
+
+class BaseForm(TbxFormsBaseForm, forms.Form):
+    pass
 
 
 class CheckboxForm(BaseForm):

--- a/tests/helpers/test_form_helper.py
+++ b/tests/helpers/test_form_helper.py
@@ -26,7 +26,6 @@ RESULT_DIR = os.path.join(TEST_DIR, "helpers", "results")
 def test_default_label_size():
     """Verify a default label size can set for fields."""
     form = TextInputForm()
-    form.helper = FormHelper(form)
     form.helper.label_size = Size.MEDIUM
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_size.html")
 
@@ -34,7 +33,6 @@ def test_default_label_size():
 def test_override_default_label_size():
     """Verify a default label size can be overridden on the field."""
     form = TextInputForm()
-    form.helper = FormHelper()
     form.helper.label_size = Size.MEDIUM
     form.helper.layout = Layout(Field.text("name", label_size=Size.LARGE))
     assert parse_form(form) == parse_contents(
@@ -45,7 +43,6 @@ def test_override_default_label_size():
 def test_default_legend_size():
     """Verify a default legend size can set for fields."""
     form = CheckboxesForm()
-    form.helper = FormHelper(form)
     form.helper.legend_size = Size.MEDIUM
     assert parse_form(form) == parse_contents(RESULT_DIR, "legend_size.html")
 
@@ -53,7 +50,6 @@ def test_default_legend_size():
 def test_override_default_legend_size():
     """Verify a default legend size can be overridden on the field."""
     form = CheckboxesForm()
-    form.helper = FormHelper()
     form.helper.legend_size = Size.MEDIUM
     form.helper.layout = Layout(
         Field.checkboxes("method", legend_size=Size.LARGE)

--- a/tests/layout/results/buttons/primary.html
+++ b/tests/layout/results/buttons/primary.html
@@ -1,3 +1,3 @@
 <button name="name"
           class="tbxforms-button tbxforms-button--primary"
-          id="id_name">Title</button>
+          id="id_name">Title<br></button>

--- a/tests/layout/results/fieldset/legend_heading.html
+++ b/tests/layout/results/fieldset/legend_heading.html
@@ -3,7 +3,7 @@
 
     <legend class="tbxforms-fieldset__legend">
       <h1 class="tbxforms-fieldset__heading">
-        Contact
+        Contact<br>
       </h1>
     </legend>
 

--- a/tests/layout/test_buttons.py
+++ b/tests/layout/test_buttons.py
@@ -4,6 +4,8 @@ Tests to verify buttons are rendered correctly.
 """
 import os
 
+from django.utils.html import mark_safe
+
 from tbxforms.layout import Button
 from tests.utils import (
     TEST_DIR,
@@ -16,8 +18,17 @@ TEMPLATE = '{% include "tbx/layout/button.html" %}'
 
 
 def test_primary_button():
-    button = Button.primary("name", "Title")
+    button = Button.primary("name", mark_safe("Title<br>"))
     assert parse_template(TEMPLATE, input=button) == parse_contents(
+        RESULT_DIR, "primary.html"
+    )
+
+
+def test_primary_button_incorrect_escaping():
+    """Without mark_safe the result shouldn't be equal, see test_primary_button
+    for the correct test case using the same template."""
+    button = Button.primary("name", "Title<br>")
+    assert parse_template(TEMPLATE, input=button) != parse_contents(
         RESULT_DIR, "primary.html"
     )
 

--- a/tests/layout/test_checkbox.py
+++ b/tests/layout/test_checkbox.py
@@ -37,7 +37,6 @@ def test_validation_error_attributes():
 def test_checkbox_size():
     """Verify size of the checkbox can be changed from the default."""
     form = CheckboxForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("accept", context={"checkboxes_small": True})
     )

--- a/tests/layout/test_checkboxes.py
+++ b/tests/layout/test_checkboxes.py
@@ -26,7 +26,6 @@ RESULT_DIR = os.path.join(TEST_DIR, "layout", "results", "checkboxes")
 def test_initial_attributes():
     """Verify all the gds attributes are displayed."""
     form = CheckboxesForm(initial={"method": ["email", "text"]})
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field.checkboxes("method"))
     assert parse_form(form) == parse_contents(RESULT_DIR, "initial.html")
 
@@ -43,7 +42,6 @@ def test_validation_error_attributes():
 def test_choices():
     """Verify that hints are displayed."""
     form = CheckboxesChoiceForm(initial={"method": ["email", "text"]})
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field.checkboxes("method"))
     assert parse_form(form) == parse_contents(RESULT_DIR, "choices.html")
 
@@ -51,7 +49,6 @@ def test_choices():
 def test_checkbox_size():
     """Verify size of the checkbox can be changed from the default."""
     form = CheckboxesForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("method", context={"checkboxes_small": True})
     )
@@ -61,7 +58,6 @@ def test_checkbox_size():
 def test_show_legend_as_heading():
     """Verify the field legend can be displayed as the page heading."""
     form = CheckboxesForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field("method", context={"legend_tag": "h1"}))
     assert parse_form(form) == parse_contents(
         RESULT_DIR, "legend_heading.html"
@@ -71,7 +67,6 @@ def test_show_legend_as_heading():
 def test_change_legend_size():
     """Verify size of the field legend can be changed from the default."""
     form = CheckboxesForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("method", context={"legend_size": Size.for_legend("l")})
     )

--- a/tests/layout/test_fieldset.py
+++ b/tests/layout/test_fieldset.py
@@ -4,6 +4,8 @@ Tests to verify fieldsets are rendered correctly.
 """
 import os
 
+from django.utils.html import mark_safe
+
 from tbxforms.helper import FormHelper
 from tbxforms.layout import (
     Fieldset,
@@ -31,9 +33,27 @@ def test_show_legend_as_heading():
     form = FieldsetForm()
     form.helper = FormHelper()
     form.helper.layout = Layout(
-        Fieldset("name", "email", legend="Contact", legend_tag="h1")
+        Fieldset(
+            "name", "email", legend=mark_safe("Contact<br>"), legend_tag="h1"
+        )
     )
     assert parse_form(form) == parse_contents(
+        RESULT_DIR, "legend_heading.html"
+    )
+
+
+def test_show_legend_as_heading_incorrect_escaping():
+    """
+    Without mark_safe the result shouldn't be equal, see
+    test_show_legend_as_heading for the correct test case using the same
+    template.
+    """
+    form = FieldsetForm()
+    form.helper = FormHelper()
+    form.helper.layout = Layout(
+        Fieldset("name", "email", legend="Contact<br>", legend_tag="h1")
+    )
+    assert parse_form(form) != parse_contents(
         RESULT_DIR, "legend_heading.html"
     )
 

--- a/tests/layout/test_fieldset.py
+++ b/tests/layout/test_fieldset.py
@@ -31,7 +31,6 @@ def test_basic_layout():
 def test_show_legend_as_heading():
     """Verify the field legend can be displayed as the page heading."""
     form = FieldsetForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Fieldset(
             "name", "email", legend=mark_safe("Contact<br>"), legend_tag="h1"
@@ -49,7 +48,6 @@ def test_show_legend_as_heading_incorrect_escaping():
     template.
     """
     form = FieldsetForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Fieldset("name", "email", legend="Contact<br>", legend_tag="h1")
     )
@@ -61,7 +59,6 @@ def test_show_legend_as_heading_incorrect_escaping():
 def test_change_legend_size():
     """Verify size of the field legend can be changed from the default."""
     form = FieldsetForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Fieldset("name", "email", legend="Contact", legend_size=Size.LARGE)
     )
@@ -71,7 +68,6 @@ def test_change_legend_size():
 def test_css_class():
     """Verify an extra CSS class can be added to the fieldset."""
     form = FieldsetForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Fieldset(css_class="extra-css-class"))
     assert parse_form(form) == parse_contents(RESULT_DIR, "css_class.html")
 
@@ -79,7 +75,6 @@ def test_css_class():
 def test_css_id():
     """Verify the id attribute can be set on the fieldset."""
     form = FieldsetForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Fieldset(css_id="new_id"))
     assert parse_form(form) == parse_contents(RESULT_DIR, "css_id.html")
 
@@ -87,6 +82,5 @@ def test_css_id():
 def test_attribute():
     """Verify the extra attributes can be added."""
     form = FieldsetForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Fieldset(key="value"))
     assert parse_form(form) == parse_contents(RESULT_DIR, "attributes.html")

--- a/tests/layout/test_file_upload.py
+++ b/tests/layout/test_file_upload.py
@@ -38,7 +38,6 @@ def test_validation_error_attributes():
 def test_show_label_as_heading():
     """Verify the field label can be displayed as the page heading."""
     form = FileUploadForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field("file", context={"label_tag": "h1"}))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_heading.html")
 
@@ -46,7 +45,6 @@ def test_show_label_as_heading():
 def test_change_label_size():
     """Verify size of the field label can be changed from the default."""
     form = FileUploadForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("file", context={"label_size": Size.for_label("l")})
     )

--- a/tests/layout/test_radios.py
+++ b/tests/layout/test_radios.py
@@ -26,7 +26,6 @@ RESULT_DIR = os.path.join(TEST_DIR, "layout", "results", "radios")
 def test_initial_attributes():
     """Verify all the gds attributes are displayed."""
     form = RadiosForm(initial={"method": "email"})
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field.radios("method"))
     assert parse_form(form) == parse_contents(RESULT_DIR, "initial.html")
 
@@ -43,7 +42,6 @@ def test_validation_error_attributes():
 def test_choices():
     """Verify hints and dividers are displayed."""
     form = RadiosChoiceForm(initial={"method": "email"})
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field.radios("method"))
     assert parse_form(form) == parse_contents(RESULT_DIR, "choices.html")
 
@@ -51,7 +49,6 @@ def test_choices():
 def test_small():
     """Verify size of the radio buttons can be changed."""
     form = RadiosForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("method", context={"radios_small": True})
     )
@@ -61,7 +58,6 @@ def test_small():
 def test_inline():
     """Verify radio buttons can be displayed in a row."""
     form = RadiosForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("method", context={"radios_inline": True})
     )
@@ -73,7 +69,6 @@ def test_inline():
 def test_show_legend_as_heading():
     """Verify the field legend can be displayed as the page heading."""
     form = RadiosForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field("method", context={"legend_tag": "h1"}))
     assert parse_form(form) == parse_contents(
         RESULT_DIR, "legend_heading.html"
@@ -83,7 +78,6 @@ def test_show_legend_as_heading():
 def test_change_legend_size():
     """Verify size of the field legend can be changed from the default."""
     form = RadiosForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("method", context={"legend_size": Size.for_legend("l")})
     )

--- a/tests/layout/test_select.py
+++ b/tests/layout/test_select.py
@@ -38,7 +38,6 @@ def test_validation_error_attributes():
 def test_show_label_as_heading():
     """Verify the field label can be displayed as the page heading."""
     form = SelectForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field("method", context={"label_tag": "h1"}))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_heading.html")
 
@@ -46,7 +45,6 @@ def test_show_label_as_heading():
 def test_change_label_size():
     """Verify size of the field label can be changed from the default."""
     form = SelectForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("method", context={"label_size": Size.for_label("l")})
     )

--- a/tests/layout/test_text_input.py
+++ b/tests/layout/test_text_input.py
@@ -38,7 +38,6 @@ def test_validation_error_attributes():
 def test_show_label_as_heading():
     """Verify the field label can be displayed as the page heading."""
     form = TextInputForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field("name", context={"label_tag": "h1"}))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_heading.html")
 
@@ -46,7 +45,6 @@ def test_show_label_as_heading():
 def test_change_label_size():
     """Verify size of the field label can be changed from the default."""
     form = TextInputForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("name", context={"label_size": Size.for_label("l")})
     )

--- a/tests/layout/test_textarea.py
+++ b/tests/layout/test_textarea.py
@@ -40,7 +40,6 @@ def test_validation_error_attributes():
 def test_show_label_as_heading():
     """Verify the field label can be displayed as the page heading."""
     form = TextareaForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("description", context={"label_tag": "h1"})
     )
@@ -50,7 +49,6 @@ def test_show_label_as_heading():
 def test_change_label_size():
     """Verify size of the field label can be changed from the default."""
     form = TextareaForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("description", context={"label_size": Size.for_label("l")})
     )
@@ -85,7 +83,6 @@ def test_no_help_text_errors():
 def test_character_count():
     """Verify the field can show the maximum number of characters allowed."""
     form = TextareaForm(initial={"description": "Field value"})
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field.textarea("description", max_characters=100)
     )
@@ -107,7 +104,6 @@ def test_threshold():
     Verify info is shown after a certain number of words has been entered.
     """
     form = TextareaForm(initial={"description": "Field value"})
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field.textarea("description", max_words=100, threshold=50)
     )


### PR DESCRIPTION
Crispy forms has removed all uses of `|safe` recently: https://github.com/django-crispy-forms/django-crispy-forms/issues/296
(except for `help_text`: https://grep.app/search?q=%7Csafe&filter[repo][0]=django-crispy-forms/django-crispy-forms but we handle those differently, so we can remove `|safe` from those too)

This PR still needs more work but so far includes the following:

* remove most uses of `|safe`, there's still a couple left though
* `BaseForm` in `tests/forms.py` now inherits from `TbxFormsBaseForm` (I'm not sure how the tests worked like that)
* `form.helper = FormHelper()` removed from all tests, it should already exists if inheriting from `TbxFormsBaseForm`
* Remove `TBXFORMS_ALLOW_HTML_BUTTON`. See also notes in README why. Basically values for buttons can be very likely always marked as safe in python (unlike label and help text, which come from field definitions and can never contain user input). So we don't need an option for this.
* We probably need more tests like `test_show_legend_as_heading_incorrect_escaping` to make sure we don't render html where we're not supposed to. 

