### PR TITLE
Upgrade/36-crispy-forms-gds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,8 @@
 -   Snapshot formatting check to CI using `djlint`
 -   Autoformatting of snapshots using `djlint`
 -   Testing accross Django versions 2.2 - 4.0 and Python versions 3.8 - 3.11 using `tox`
+-   Support for dividers on checkbox fields
+
+### Fixed
+
+-   `DateInputField` raises a `ValidationError` (instead of `ValueError`) when given invalid input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@
 ### Fixed
 
 -   `DateInputField` raises a `ValidationError` (instead of `ValueError`) when given invalid input
+-   `DateInputField` with `required=False` no longer raises a `ValueError` when no values are passed

--- a/tbxforms/fields.py
+++ b/tbxforms/fields.py
@@ -181,6 +181,9 @@ class DateInputField(forms.MultiValueField):
         """
         day, month, year = data_list
         if day and month and year:
-            return date(day=int(day), month=int(month), year=int(year))
+            try:
+                return date(day=int(day), month=int(month), year=int(year))
+            except ValueError as e:
+                raise ValidationError(str(e)) from e
         else:
             return None

--- a/tbxforms/fields.py
+++ b/tbxforms/fields.py
@@ -179,11 +179,12 @@ class DateInputField(forms.MultiValueField):
                 fields. If any of the field are blank then None is returned.
 
         """
-        day, month, year = data_list
-        if day and month and year:
-            try:
-                return date(day=int(day), month=int(month), year=int(year))
-            except ValueError as e:
-                raise ValidationError(str(e)) from e
-        else:
-            return None
+        if len(data_list) == 3:
+            day, month, year = data_list
+            if day and month and year:
+                try:
+                    return date(day=int(day), month=int(month), year=int(year))
+                except ValueError as e:
+                    raise ValidationError(str(e)) from e
+
+        return None

--- a/tbxforms/templates/tbx/layout/checkboxes.html
+++ b/tbxforms/templates/tbx/layout/checkboxes.html
@@ -45,6 +45,10 @@
                         {{ choice.hint }}
                     </span>
                 {% endif %}
+
+                {% if choice.divider %}
+                    <div class="tbxforms-checkboxes__divider">{{ choice.divider }}</div>
+                {% endif %}
             </div>
         {% endfor %}
     </div>

--- a/tests/fields/test_date_input_field.py
+++ b/tests/fields/test_date_input_field.py
@@ -11,6 +11,17 @@ import pytest
 from tbxforms.fields import DateInputField
 
 
+def test_compress_invalid_fields():
+    """Verify compress raises an error on an invalid date."""
+    day = 30
+    month = 2
+    year = 2021
+    field = DateInputField()
+    with pytest.raises(ValidationError) as err:
+        field.compress([day, month, year])
+    assert str(err) == "day is out of range for month"
+
+
 def test_compress_valid_fields():
     """Verify compress returns a date."""
     date = datetime.date(year=2007, month=12, day=11)

--- a/tests/fields/test_date_input_field.py
+++ b/tests/fields/test_date_input_field.py
@@ -13,11 +13,12 @@ from tbxforms.fields import DateInputField
 
 def test_compress_invalid_fields():
     """Verify compress raises an error on an invalid date."""
-    date = datetime.date(year=2021, month=2, day=30)
+    day = 30
+    month = 2
+    year = 2021
     field = DateInputField()
-    with pytest.raises(ValidationError) as err:
-        field.compress([date.day, date.month, date.year])
-    assert err.message == "day is out of range for month"
+    with pytest.raises(ValidationError, match="day is out of range for month"):
+        field.compress([day, month, year])
 
 
 def test_compress_valid_fields():

--- a/tests/fields/test_date_input_field.py
+++ b/tests/fields/test_date_input_field.py
@@ -13,13 +13,11 @@ from tbxforms.fields import DateInputField
 
 def test_compress_invalid_fields():
     """Verify compress raises an error on an invalid date."""
-    day = 30
-    month = 2
-    year = 2021
+    date = datetime.date(year=2021, month=2, day=30)
     field = DateInputField()
     with pytest.raises(ValidationError) as err:
-        field.compress([day, month, year])
-    assert str(err) == "day is out of range for month"
+        field.compress([date.day, date.month, date.year])
+    assert err.message == "day is out of range for month"
 
 
 def test_compress_valid_fields():

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -48,7 +48,8 @@ class CheckboxesChoiceForm(BaseForm):
             "Phone",
             hint="Select this option only if you have a mobile phone",
         ),
-        Choice("text", "Text message"),
+        Choice("text", "Text message", divider="or"),
+        Choice("none", "None of the above"),
     )
 
     method = forms.ChoiceField(

--- a/tests/layout/__snapshots__/test_checkboxes/test_choices.html
+++ b/tests/layout/__snapshots__/test_checkboxes/test_choices.html
@@ -33,6 +33,15 @@
                            value="text"
                            checked="checked" />
                     <label class="tbxforms-label tbxforms-checkboxes__label" for="id_method_3">Text message</label>
+                    <div class="tbxforms-checkboxes__divider">or</div>
+                </div>
+                <div class="tbxforms-checkboxes__item">
+                    <input type="checkbox"
+                           name="method"
+                           class="tbxforms-checkboxes__input"
+                           id="id_method_4"
+                           value="none" />
+                    <label class="tbxforms-label tbxforms-checkboxes__label" for="id_method_4">None of the above</label>
                 </div>
             </div>
         </fieldset>

--- a/tests/layout/__snapshots__/test_date_input/test_non_required_field_left_blank_does_not_raise_exception.html
+++ b/tests/layout/__snapshots__/test_date_input/test_non_required_field_left_blank_does_not_raise_exception.html
@@ -1,0 +1,43 @@
+<form method="post">
+    <div id="div_id_date" class="tbxforms-form-group">
+        <fieldset class="tbxforms-fieldset"  aria-describedby="id_date_hint">
+            <legend class="tbxforms-fieldset__legend">When was your passport issued?</legend>
+            <span id="id_date_hint" class="tbxforms-hint">For example, 12 11 2007</span>
+            <div class="tbxforms-date-input" id="id_date">
+                <div class="tbxforms-date-input__item">
+                    <div class="tbxforms-form-group">
+                        <label class="tbxforms-label tbxforms-date-input__label" for="id_date_0">Day</label>
+                        <input type="text"
+                               name="date_0"
+                               class="tbxforms-input tbxforms-input--text tbxforms-date-input__input tbxforms-input--width-2"
+                               pattern="[0-9]*"
+                               inputmode="numeric"
+                               id="id_date_0">
+                    </div>
+                </div>
+                <div class="tbxforms-date-input__item">
+                    <div class="tbxforms-form-group">
+                        <label class="tbxforms-label tbxforms-date-input__label" for="id_date_1">Month</label>
+                        <input type="text"
+                               name="date_1"
+                               class="tbxforms-input tbxforms-input--text tbxforms-date-input__input tbxforms-input--width-2"
+                               pattern="[0-9]*"
+                               inputmode="numeric"
+                               id="id_date_1">
+                    </div>
+                </div>
+                <div class="tbxforms-date-input__item">
+                    <div class="tbxforms-form-group">
+                        <label class="tbxforms-label tbxforms-date-input__label" for="id_date_2">Year</label>
+                        <input type="text"
+                               name="date_2"
+                               class="tbxforms-input tbxforms-input--text tbxforms-date-input__input tbxforms-input--width-4"
+                               pattern="[0-9]*"
+                               inputmode="numeric"
+                               id="id_date_2">
+                    </div>
+                </div>
+            </div>
+        </fieldset>
+    </div>
+</form>

--- a/tests/layout/test_date_input.py
+++ b/tests/layout/test_date_input.py
@@ -38,3 +38,11 @@ def test_subfield_error_attributes(snapshot_html):
     form = DateInputForm(data={"date_0": "a", "date_1": "11", "date_2": ""})
     assert not form.is_valid()
     assert render_form(form) == snapshot_html
+
+
+def test_non_required_field_left_blank_does_not_raise_exception(snapshot_html):
+    """Verify all the gds attributes are displayed."""
+    form = DateInputForm(data={"date_0": "", "date_1": "", "date_2": ""})
+    form.fields["date"].required = False
+    assert form.is_valid()
+    assert render_form(form) == snapshot_html


### PR DESCRIPTION
The following merged PRs to crispy-forms-gds can be pulled into our package:

1. https://github.com/wildfish/crispy-forms-gds/pull/59

 2. https://github.com/wildfish/crispy-forms-gds/pull/76:
                  - we will need to check the CSS class name for the divider markup
                  - see https://design-system.service.gov.uk/components/radios/ - the divider should be used to separate answers that are conceptually different