### PR TITLE
Reuse our BaseForm class within tests and fix uncovered issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@
 -   Template linting to CI using `djlint`
 -   Snapshot formatting check to CI using `djlint`
 -   Autoformatting of snapshots using `djlint`
--   Testing accross Django versions 2.2 - 4.0 and Python versions 3.8 - 3.11 using `tox`
+-   Testing across Django versions 2.2 - 4.0 and Python versions 3.8 - 3.11 using `tox`
 
 ### Changed
 
 -   Use snapshot testing plugin (syrupy) for component rendering tests instead of HTML fixtures
+-   form.helper (`FormHelper`) changed from a static `@property` to the form's `__init__` method to allow changes at runtime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,7 @@
 
 -   Use snapshot testing plugin (syrupy) for component rendering tests instead of HTML fixtures
 -   form.helper (`FormHelper`) changed from a static `@property` to the form's `__init__` method to allow changes at runtime.
+
+### Fixed
+
+-   `Field.select` label size and tag can be changed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 > All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Types of changes
+
+-   `Added` for new features.
+-   `Changed` for changes in existing functionality.
+-   `Deprecated` for soon-to-be removed features.
+-   `Dev` for changes to the developer experience.
+-   `Fixed` for bug fixes.
+-   `Removed` for now removed features.
+-   `Security` in case of vulnerabilities.
+
 ## Unreleased
-
-### Changed
-
--   Use snapshot testing plugin (syrupy) for component rendering tests instead of HTML fixtures
 
 ### Added
 
@@ -14,3 +20,7 @@
 -   Snapshot formatting check to CI using `djlint`
 -   Autoformatting of snapshots using `djlint`
 -   Testing accross Django versions 2.2 - 4.0 and Python versions 3.8 - 3.11 using `tox`
+
+### Changed
+
+-   Use snapshot testing plugin (syrupy) for component rendering tests instead of HTML fixtures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
 ### Changed
 
 -   Use snapshot testing plugin (syrupy) for component rendering tests instead of HTML fixtures
--   form.helper (`FormHelper`) changed from a static `@property` to the form's `__init__` method to allow changes at runtime.
+-   form.helper (`FormHelper`) changed from a static `@property` to the form's `__init__` method to allow changes at runtime
+-   `BaseForm` renamed to `TbxFormsMixin` to more accurately convey what it is
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -106,16 +106,16 @@ You will need to write button styles for the following classes:
 
 ### Django forms
 
-All forms must inherit from `TbxFormsBaseForm` and a Django base form class.
+All forms must inherit the `TbxFormsMixin` mixin, as well as specifying a Django base form class (e.g. `forms.Form` or `forms.ModelForm`)
 
 ```python
 from django import forms
-from tbxforms.forms import BaseForm as TbxFormsBaseForm
+from tbxforms.forms import TbxFormsMixin
 
-class ExampleForm(TbxFormsBaseForm, forms.Form):
+class ExampleForm(TbxFormsMixin, forms.Form):
     ...
 
-class ExampleModelForm(TbxFormsBaseForm, forms.ModelForm):
+class ExampleModelForm(TbxFormsMixin, forms.ModelForm):
     ...
 ```
 
@@ -123,13 +123,13 @@ class ExampleModelForm(TbxFormsBaseForm, forms.ModelForm):
 
 #### Create or update a Wagtail form
 
-Wagtail forms must inherit from `TbxFormsBaseForm` and `WagtailBaseForm`.
+Wagtail forms must inherit from `TbxFormsMixin` and `WagtailBaseForm`.
 
 ```python
 from wagtail.contrib.forms.forms import BaseForm as WagtailBaseForm
-from tbxforms.forms import BaseForm as TbxFormsBaseForm
+from tbxforms.forms import TbxFormsMixin
 
-class ExampleWagtailForm(TbxFormsBaseForm, WagtailBaseForm):
+class ExampleWagtailForm(TbxFormsMixin, WagtailBaseForm):
     ...
 ```
 
@@ -177,7 +177,7 @@ Just like Django Crispy Forms, you need to pass your form object to the
 A [FormHelper](https://django-crispy-forms.readthedocs.io/en/latest/form_helper.html)
 allows you to alter the rendering behaviour of forms.
 
-Every form that inherits from `TbxFormsBaseForm` (i.e. every form within `tbxforms`)
+Every form that inherits from `TbxFormsMixin` (i.e. every form within `tbxforms`)
 will have a `FormHelper` with the following default attributes:
 
 -   `html5_required = True`
@@ -197,10 +197,10 @@ Extend during instantiation:
 
 ```python
 from django import forms
-from tbxforms.forms import BaseForm as TbxFormsBaseForm
+from tbxforms.forms import TbxFormsMixin
 from tbxforms.layout import Button
 
-class YourSexyForm(TbxFormsBaseForm, forms.Form):
+class YourSexyForm(TbxFormsMixin, forms.Form):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -246,10 +246,10 @@ as required, though will technically be `required=False`.
 from django import forms
 from django.core.exceptions import ValidationError
 from tbxforms.choices import Choice
-from tbxforms.forms import BaseForm as TbxFormsBaseForm
+from tbxforms.forms import TbxFormsMixin
 from tbxforms.layout import Field, Layout
 
-class ExampleForm(TbxFormsBaseForm, forms.Form):
+class ExampleForm(TbxFormsMixin, forms.Form):
     NEWSLETTER_CHOICES = (
         Choice("yes", "Yes please", hint="Receive occasional email newsletters."),
         Choice("no", "No thanks"),

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Out of the box, forms created with `tbxforms` will look like the
 [GOV.UK Design System](https://design-system.service.gov.uk/), though many
 variables can be customised.
 
-## Key dependencies
+## Requirements
 
 -   Python `>=3.8.1,<4.0`
 -   Django (`>=2.2,<=4.0`)
--   Wagtail (`>=2.15`)
+-   Optional (if using `WagtailBaseForm`): Wagtail (`>=2.15`)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -119,12 +119,10 @@ from django import forms
 from tbxforms.forms import BaseForm as TbxFormsBaseForm
 
 class ExampleForm(TbxFormsBaseForm, forms.Form):
-    # < Your field definitions and helper property >
-
+    ...
 
 class ExampleModelForm(TbxFormsBaseForm, forms.ModelForm):
-    # < Your field definitions, ModelForm config, and helper property >
-
+    ...
 ```
 
 ### Wagtail forms
@@ -140,8 +138,7 @@ from wagtail.contrib.forms.forms import BaseForm as WagtailBaseForm
 from tbxforms.forms import BaseForm as TbxFormsBaseForm
 
 class ExampleWagtailForm(TbxFormsBaseForm, WagtailBaseForm):
-    # < Your helper property >
-
+    ...
 ```
 
 #### Instruct a Wagtail Page model to use your form
@@ -201,7 +198,6 @@ just like you would do with any other inherited class, e.g.:
 
 ```python
 from django import forms
-from wagtail.contrib.forms.forms import BaseForm as WagtailBaseForm
 from tbxforms.forms import BaseForm as TbxFormsBaseForm
 from tbxforms.layout import Button, Size
 
@@ -214,7 +210,7 @@ class YourSexyForm(TbxFormsBaseForm, forms.Form):
         # Override some settings
         fh.html5_required = False
         fh.label_size = Size.SMALL
-        fh.form_error_title = _("Something's wrong, yo.")
+        fh.form_error_title = "Something's wrong, yo."
 
         # Add a submit button
         fh.layout.extend([
@@ -253,6 +249,7 @@ as required, though will technically be `required=False`.
 
 ```python
 from django import forms
+from django.core.exceptions import ValidationError
 from tbxforms.choices import Choice
 from tbxforms.forms import BaseForm as TbxFormsBaseForm
 from tbxforms.layout import Field, Layout
@@ -314,7 +311,7 @@ class ExampleForm(TbxFormsBaseForm, forms.Form):
         if newsletter_signup == "yes" and not email:
             raise ValidationError(
                 {
-                    "email": _("This field is required."),
+                    "email": "This field is required.",
                 }
             )
         # The tbxforms JS will attempt to clear any redundant data upon submission,
@@ -333,7 +330,7 @@ can use the exact same `data_conditional` definition as above but on a `div` or
 `fieldset` element, e.g.:
 
 ```python
-from tbxforms.layout import HTML, Div, Field
+from tbxforms.layout import HTML, Div, Field, Layout
 
 Layout(
     Div(

--- a/README.md
+++ b/README.md
@@ -9,25 +9,29 @@ Out of the box, forms created with `tbxforms` will look like the
 [GOV.UK Design System](https://design-system.service.gov.uk/), though many
 variables can be customised.
 
+## Key dependencies
+
+-   Python `>=3.8.1,<4.0`
+-   Django (`>=2.2,<=4.0`)
+-   Wagtail (`>=2.15`)
+
 ## Installation
 
 You must install both the Python package and the NPM package.
 
 ### Install the Python package
 
-#### Install using pip
+Install using pip:
 
 ```bash
 pip install tbxforms
 ```
 
-#### Update/define settings
-
 Add `django-crispy-forms` and `tbxforms` to your installed apps:
 
 ```python
 INSTALLED_APPS = [
-  ...
+  # ...
   'crispy_forms',  # django-crispy-forms
   'tbxforms',
 ]
@@ -40,27 +44,19 @@ CRISPY_ALLOWED_TEMPLATE_PACKS = ["tbx"]
 CRISPY_TEMPLATE_PACK = "tbx"
 ```
 
-There are two optional settings which will control whether HTML is rendered for
-a field's `label` and `help_text`. The defaults are set to `False`
-(which escapes the HTML and prevents it from being rendered):
-
-```python
-TBXFORMS_ALLOW_HTML_LABEL = False
-TBXFORMS_ALLOW_HTML_HELP_TEXT = False
-TBXFORMS_ALLOW_HTML_BUTTON = False
-```
-
 ### Install the NPM package
 
-#### Install using NPM
+Install using NPM:
 
 ```bash
 npm install tbxforms
 ```
 
-This package uses the `Element.closest`, `NodeList.forEach`, and `Array.includes` APIs. You will additionally need to install and configure polyfills for legacy browser support.
+Note: This package uses the `Element.closest`, `NodeList.forEach`, and
+`Array.includes` APIs. You will need to install and configure polyfills for
+legacy browser support if you need to.
 
-#### Instantiate your forms
+Instantiate your forms:
 
 ```javascript
 import TbxForms from 'tbxforms';
@@ -72,7 +68,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 ```
 
-#### Import the styles into your project
+Import the styles into your project...
 
 ...Either as CSS without any customisations:
 
@@ -95,7 +91,7 @@ such as [tbxforms/static/sass/abstracts/\_variables.scss](https://github.com/tor
 #### Add button styles
 
 `tbxforms` provides out-of-the-box GOV.UK Design System styles for everything
-except buttons, as styles for these probably exist in your project.
+except buttons, as styles for these probably exist within your project.
 
 You will need to write button styles for the following classes:
 
@@ -106,13 +102,11 @@ You will need to write button styles for the following classes:
 
 ## Usage
 
-`tbxforms` supports Django (`>=2.2,<=4.0`) and Wagtail (`>=2.15`) forms.
+`tbxforms` can be used for coded Django forms and editor-controlled Wagtail forms.
 
 ### Django forms
 
-`django>=2.2,<=4.0` is supported.
-
-All forms must inherit from `TbxFormsBaseForm` and whichever Django base form class.
+All forms must inherit from `TbxFormsBaseForm` and a Django base form class.
 
 ```python
 from django import forms
@@ -127,11 +121,9 @@ class ExampleModelForm(TbxFormsBaseForm, forms.ModelForm):
 
 ### Wagtail forms
 
-`wagtail>=2.15` is supported.
-
 #### Create or update a Wagtail form
 
-Wagtail forms must inheirt from `TbxFormsBaseForm` and `WagtailBaseForm`.
+Wagtail forms must inherit from `TbxFormsBaseForm` and `WagtailBaseForm`.
 
 ```python
 from wagtail.contrib.forms.forms import BaseForm as WagtailBaseForm
@@ -172,20 +164,21 @@ Just like Django Crispy Forms, you need to pass your form object to the
 
 ```html
 {% load crispy_forms_tags %}
+
 <html>
     <body>
-        {% crispy your_form %}
+        {% crispy your_sexy_form %}
     </body>
 </html>
 ```
 
-### Add a submit button and customise the form via the `helper` property
+### `FormHelper`s
 
-Submit buttons are not automatically added - you will need to do this by
-extending the form helper's `layout` (example below).
+A [FormHelper](https://django-crispy-forms.readthedocs.io/en/latest/form_helper.html)
+allows you to alter the rendering behaviour of forms.
 
-Every form that inherits from `TbxFormsBaseForm` will have the following
-attributes set:
+Every form that inherits from `TbxFormsBaseForm` (i.e. every form within `tbxforms`)
+will have a `FormHelper` with the following default attributes:
 
 -   `html5_required = True`
 -   `label_size = Size.MEDIUM`
@@ -193,45 +186,47 @@ attributes set:
 -   `form_error_title = _("There is a problem with your submission")`
 -   Plus everything from [django-crispy-forms' default attributes](https://django-crispy-forms.readthedocs.io/en/latest/form_helper.html).
 
-These can be overridden (and/or additional attributes from the above list defined)
-just like you would do with any other inherited class, e.g.:
+These can be changed during instantiation or [on the go](https://django-crispy-forms.readthedocs.io/en/latest/dynamic_layouts.html) - examples below.
+
+#### Add a submit button
+
+Submit buttons are not automatically added to forms. To add one, you can extend
+the `form.helper.layout` (examples below).
+
+Extend during instantiation:
 
 ```python
 from django import forms
 from tbxforms.forms import BaseForm as TbxFormsBaseForm
-from tbxforms.layout import Button, Size
+from tbxforms.layout import Button
 
 class YourSexyForm(TbxFormsBaseForm, forms.Form):
 
-    @property
-    def helper(self):
-        fh = super().helper
-
-        # Override some settings
-        fh.html5_required = False
-        fh.label_size = Size.SMALL
-        fh.form_error_title = "Something's wrong, yo."
-
-        # Add a submit button
-        fh.layout.extend([
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout.extend([
             Button.primary(
                 name="submit",
                 type="submit",
                 value="Submit",
             )
         ])
-        return fh
-
 ```
 
-#### Change the label and legend classes
+Or afterwards:
 
-Possible values for the `label_size` and `legend_size`:
+```python
+from tbxforms.layout import Button
 
-1. `SMALL`
-2. `MEDIUM` (default)
-3. `LARGE`
-4. `EXTRA_LARGE`
+form = YourSexyForm()
+form.helper.layout.extend([
+    Button.primary(
+        name="submit",
+        type="submit",
+        value="Submit",
+    )
+])
+```
 
 ### Conditionally-required fields
 
@@ -268,20 +263,9 @@ class ExampleForm(TbxFormsBaseForm, forms.Form):
         widget=forms.EmailInput(required=False)
     )
 
-    @staticmethod
-    def conditional_fields_to_show_as_required() -> [str]:
-        # Non-required fields that should show as required to the user.
-        return [
-            "email",
-        ]
-
-    @property
-    def helper(self):
-        fh = super().helper
-
-        # Override what is rendered for this form.
-        fh.layout = Layout(
-
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout = Layout(
             # Add our newsletter sign-up field.
             Field("newsletter_signup"),
 
@@ -293,11 +277,14 @@ class ExampleForm(TbxFormsBaseForm, forms.Form):
                     "values": ["yes"], # Value(s) to cause this field to show.
                 },
             ),
-
         )
 
-        return fh
-
+    @staticmethod
+    def conditional_fields_to_show_as_required() -> [str]:
+        # Non-required fields that should show as required to the user.
+        return [
+            "email",
+        ]
 
     def clean(self):
         cleaned_data = super().clean()
@@ -344,6 +331,28 @@ Layout(
     ),
 )
 ```
+
+## Customising behaviour
+
+### Allow HTML markup within labels and help text
+
+Markup within labels and help text is disabled by default, though can be
+enabled via:
+
+```python
+TBXFORMS_ALLOW_HTML_LABEL = False
+TBXFORMS_ALLOW_HTML_HELP_TEXT = False
+TBXFORMS_ALLOW_HTML_BUTTON = False
+```
+
+### Change the default label and legend classes
+
+Possible values for the `label_size` and `legend_size`:
+
+1. `SMALL`
+2. `MEDIUM` (default)
+3. `LARGE`
+4. `EXTRA_LARGE`
 
 # Further reading
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,5 +97,5 @@ extension = "html"
 profile = "django"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core==1.5.1"]
 build-backend = "poetry.core.masonry.api"

--- a/tbxforms/forms.py
+++ b/tbxforms/forms.py
@@ -11,7 +11,7 @@ if apps.is_installed("wagtail.contrib.forms"):
     from wagtail.contrib.forms.forms import FormBuilder
 
 
-class BaseForm:
+class TbxFormsMixin:
     @staticmethod
     def conditional_fields_to_show_as_required() -> []:
         """

--- a/tbxforms/forms.py
+++ b/tbxforms/forms.py
@@ -22,19 +22,14 @@ class BaseForm:
         """
         return []
 
-    @property
-    def helper(self) -> FormHelper:
-        fh = FormHelper(self)
-        fh.form_class = "tbxforms"  # Must include `tbxforms`.
-
-        # Define some defaults.
-        fh.html5_required = True
-        fh.label_size = Size.MEDIUM
-        fh.legend_size = Size.MEDIUM
-        return fh
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper(self)
+        self.helper.form_class = "tbxforms"  # Must include `tbxforms`.
+        self.helper.html5_required = True
+        self.helper.label_size = Size.MEDIUM
+        self.helper.legend_size = Size.MEDIUM
 
         # Escape HTML within `label` and `help_text` unless it's set to allow.
         # NB. Also see https://github.com/torchbox/tbxforms/blob/main/tbxforms/layout/buttons.py#L102  # noqa: E501

--- a/tbxforms/layout/fields.py
+++ b/tbxforms/layout/fields.py
@@ -72,7 +72,12 @@ class Field(crispy_forms_layout.LayoutObject):
     template = "%s/field.html"
 
     @classmethod
-    def checkbox(cls, field, small=False, **kwargs):
+    def checkbox(
+        cls,
+        field,
+        small=False,
+        **kwargs,
+    ):
         """
         Create a field for displaying a single checkbox.
 
@@ -88,7 +93,12 @@ class Field(crispy_forms_layout.LayoutObject):
 
     @classmethod
     def checkboxes(
-        cls, field, legend_size=None, legend_tag=None, small=False, **kwargs
+        cls,
+        field,
+        legend_size=None,
+        legend_tag=None,
+        small=False,
+        **kwargs,
     ):
         """
         Create a field for displaying a set of checkboxes.
@@ -166,18 +176,24 @@ class Field(crispy_forms_layout.LayoutObject):
         return Field(field, context=context, **kwargs)
 
     @classmethod
-    def select(cls, field, legend_size=None, legend_tag=None, **kwargs):
+    def select(
+        cls,
+        field,
+        label_size=None,
+        label_tag=None,
+        **kwargs,
+    ):
         """
         Create a field for displaying a select drop-down.
 
         Args:
             field (str): the name of the field.
 
-            legend_size (str): the size of the legend. The default is None in
-                which case the legend will be rendered at the same size as
+            label_size (str): the size of the label. The default is None in
+                which case the label will be rendered at the same size as
                 regular text.
 
-            legend_tag (str): Wrap the field legend with this HTML tag.
+            label_tag (str): Wrap the field label with this HTML tag.
                 Default is None.
 
             **kwargs: Attributes to add to the <select> element when the field
@@ -186,17 +202,22 @@ class Field(crispy_forms_layout.LayoutObject):
         """
         context = {}
 
-        if legend_size:
-            context["legend_size"] = Size.for_legend(legend_size)
+        if label_size:
+            context["label_size"] = Size.for_label(label_size)
 
-        if legend_tag:
-            context["legend_tag"] = legend_tag
+        if label_tag:
+            context["label_tag"] = label_tag
 
         return Field(field, context=context, **kwargs)
 
     @classmethod
     def text(
-        cls, field, label_size=None, label_tag=None, field_width=None, **kwargs
+        cls,
+        field,
+        label_size=None,
+        label_tag=None,
+        field_width=None,
+        **kwargs,
     ):
         """
         Create a field for displaying a Text input.
@@ -318,7 +339,12 @@ class Field(crispy_forms_layout.LayoutObject):
         return Field(field, context=context, **kwargs)
 
     def __init__(
-        self, *fields, css_class=None, context=None, template=None, **kwargs
+        self,
+        *fields,
+        css_class=None,
+        context=None,
+        template=None,
+        **kwargs,
     ):
         self.fields = list(fields)
 
@@ -407,7 +433,12 @@ class Field(crispy_forms_layout.LayoutObject):
         )
 
     def render(
-        self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs
+        self,
+        form,
+        form_style,
+        context,
+        template_pack=TEMPLATE_PACK,
+        **kwargs,
     ):
         template = self.get_template_name(template_pack)
         return self.get_rendered_fields(

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -3,8 +3,8 @@ from django import forms
 from tbxforms.choices import Choice
 from tbxforms.fields import DateInputField
 from tbxforms.forms import BaseForm
-from tbxforms.helper import FormHelper
 from tbxforms.layout import (
+    Field,
     Fieldset,
     Layout,
 )
@@ -16,6 +16,12 @@ class CheckboxForm(BaseForm, forms.Form):
         help_text="Please read the terms of service.",
         error_messages={"required": "You must accept our terms of service"},
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout = Layout(
+            Field("accept"),
+        )
 
 
 class CheckboxesForm(BaseForm, forms.Form):
@@ -30,6 +36,12 @@ class CheckboxesForm(BaseForm, forms.Form):
         help_text="Select all options that are relevant to you.",
         error_messages={"required": "Enter the ways to contact you"},
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout = Layout(
+            Field("method"),
+        )
 
 
 class CheckboxesChoiceForm(BaseForm, forms.Form):
@@ -51,6 +63,12 @@ class CheckboxesChoiceForm(BaseForm, forms.Form):
         error_messages={"required": "Enter the ways to contact you"},
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout = Layout(
+            Field("method"),
+        )
+
 
 class DateInputForm(BaseForm, forms.Form):
     date = DateInputField(
@@ -58,6 +76,12 @@ class DateInputForm(BaseForm, forms.Form):
         help_text="For example, 12 11 2007",
         require_all_fields=False,
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout = Layout(
+            Field("date"),
+        )
 
 
 class FileUploadForm(BaseForm, forms.Form):
@@ -68,6 +92,12 @@ class FileUploadForm(BaseForm, forms.Form):
             "required": "Select the CSV file you exported from the spreadsheet"
         },
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout = Layout(
+            Field("file"),
+        )
 
 
 class RadiosForm(BaseForm, forms.Form):
@@ -82,6 +112,12 @@ class RadiosForm(BaseForm, forms.Form):
         help_text="Select the most convenient way to contact you.",
         error_messages={"required": "Enter the best way to contact you"},
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout = Layout(
+            Field("method"),
+        )
 
 
 class RadiosChoiceForm(BaseForm, forms.Form):
@@ -99,6 +135,12 @@ class RadiosChoiceForm(BaseForm, forms.Form):
         error_messages={"required": "Enter the best way to contact you"},
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout = Layout(
+            Field("method"),
+        )
+
 
 class SelectForm(BaseForm, forms.Form):
     method = forms.ChoiceField(
@@ -114,6 +156,12 @@ class SelectForm(BaseForm, forms.Form):
         error_messages={"required": "Enter the best way to contact you"},
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout = Layout(
+            Field("method"),
+        )
+
 
 class TextInputForm(BaseForm, forms.Form):
     name = forms.CharField(
@@ -121,6 +169,12 @@ class TextInputForm(BaseForm, forms.Form):
         help_text="Help text",
         error_messages={"required": "Required error message"},
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout = Layout(
+            Field("name"),
+        )
 
 
 class TextareaForm(BaseForm, forms.Form):
@@ -131,15 +185,19 @@ class TextareaForm(BaseForm, forms.Form):
         error_messages={"required": "Required error message"},
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout = Layout(
+            Field("description"),
+        )
+
 
 class FieldsetForm(BaseForm, forms.Form):
     name = forms.CharField(label="Name")
     email = forms.CharField(label="Email")
 
-    @property
-    def helper(self) -> FormHelper:
-        fh = super().helper
-        fh.layout = Layout(
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout = Layout(
             Fieldset("name", "email", legend="Contact"),
         )
-        return fh

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -20,7 +20,7 @@ class CheckboxForm(BaseForm, forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper.layout = Layout(
-            Field("accept"),
+            Field.checkbox("accept"),
         )
 
 
@@ -40,7 +40,7 @@ class CheckboxesForm(BaseForm, forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper.layout = Layout(
-            Field("method"),
+            Field.checkboxes("method"),
         )
 
 
@@ -66,7 +66,7 @@ class CheckboxesChoiceForm(BaseForm, forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper.layout = Layout(
-            Field("method"),
+            Field.checkboxes("method"),
         )
 
 
@@ -116,7 +116,7 @@ class RadiosForm(BaseForm, forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper.layout = Layout(
-            Field("method"),
+            Field.radios("method"),
         )
 
 
@@ -138,7 +138,7 @@ class RadiosChoiceForm(BaseForm, forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper.layout = Layout(
-            Field("method"),
+            Field.radios("method"),
         )
 
 
@@ -159,7 +159,7 @@ class SelectForm(BaseForm, forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper.layout = Layout(
-            Field("method"),
+            Field.select("method"),
         )
 
 
@@ -173,7 +173,7 @@ class TextInputForm(BaseForm, forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper.layout = Layout(
-            Field("name"),
+            Field.text("name"),
         )
 
 
@@ -188,7 +188,7 @@ class TextareaForm(BaseForm, forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper.layout = Layout(
-            Field("description"),
+            Field.textarea("description"),
         )
 
 

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -2,7 +2,7 @@ from django import forms
 
 from tbxforms.choices import Choice
 from tbxforms.fields import DateInputField
-from tbxforms.forms import BaseForm
+from tbxforms.forms import TbxFormsMixin
 from tbxforms.layout import (
     Field,
     Fieldset,
@@ -10,7 +10,7 @@ from tbxforms.layout import (
 )
 
 
-class CheckboxForm(BaseForm, forms.Form):
+class CheckboxForm(TbxFormsMixin, forms.Form):
     accept = forms.BooleanField(
         label="I accept the terms of service",
         help_text="Please read the terms of service.",
@@ -24,7 +24,7 @@ class CheckboxForm(BaseForm, forms.Form):
         )
 
 
-class CheckboxesForm(BaseForm, forms.Form):
+class CheckboxesForm(TbxFormsMixin, forms.Form):
     method = forms.ChoiceField(
         choices=(
             ("email", "Email"),
@@ -44,7 +44,7 @@ class CheckboxesForm(BaseForm, forms.Form):
         )
 
 
-class CheckboxesChoiceForm(BaseForm, forms.Form):
+class CheckboxesChoiceForm(TbxFormsMixin, forms.Form):
     METHODS = (
         Choice("email", "Email"),
         Choice(
@@ -70,7 +70,7 @@ class CheckboxesChoiceForm(BaseForm, forms.Form):
         )
 
 
-class DateInputForm(BaseForm, forms.Form):
+class DateInputForm(TbxFormsMixin, forms.Form):
     date = DateInputField(
         label="When was your passport issued?",
         help_text="For example, 12 11 2007",
@@ -84,7 +84,7 @@ class DateInputForm(BaseForm, forms.Form):
         )
 
 
-class FileUploadForm(BaseForm, forms.Form):
+class FileUploadForm(TbxFormsMixin, forms.Form):
     file = forms.FileField(
         label="Upload a file",
         help_text="Select the CSV file to upload.",
@@ -100,7 +100,7 @@ class FileUploadForm(BaseForm, forms.Form):
         )
 
 
-class RadiosForm(BaseForm, forms.Form):
+class RadiosForm(TbxFormsMixin, forms.Form):
     method = forms.ChoiceField(
         choices=(
             ("email", "Email"),
@@ -120,7 +120,7 @@ class RadiosForm(BaseForm, forms.Form):
         )
 
 
-class RadiosChoiceForm(BaseForm, forms.Form):
+class RadiosChoiceForm(TbxFormsMixin, forms.Form):
     METHODS = (
         Choice("email", "Email", hint="Do not give a work email address"),
         Choice("phone", "Phone", divider="Or"),
@@ -142,7 +142,7 @@ class RadiosChoiceForm(BaseForm, forms.Form):
         )
 
 
-class SelectForm(BaseForm, forms.Form):
+class SelectForm(TbxFormsMixin, forms.Form):
     method = forms.ChoiceField(
         choices=(
             ("", "Choose"),
@@ -163,7 +163,7 @@ class SelectForm(BaseForm, forms.Form):
         )
 
 
-class TextInputForm(BaseForm, forms.Form):
+class TextInputForm(TbxFormsMixin, forms.Form):
     name = forms.CharField(
         label="Name",
         help_text="Help text",
@@ -177,7 +177,7 @@ class TextInputForm(BaseForm, forms.Form):
         )
 
 
-class TextareaForm(BaseForm, forms.Form):
+class TextareaForm(TbxFormsMixin, forms.Form):
     description = forms.CharField(
         label="Description",
         widget=forms.Textarea,
@@ -192,7 +192,7 @@ class TextareaForm(BaseForm, forms.Form):
         )
 
 
-class FieldsetForm(BaseForm, forms.Form):
+class FieldsetForm(TbxFormsMixin, forms.Form):
     name = forms.CharField(label="Name")
     email = forms.CharField(label="Email")
 

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -2,6 +2,7 @@ from django import forms
 
 from tbxforms.choices import Choice
 from tbxforms.fields import DateInputField
+from tbxforms.forms import BaseForm
 from tbxforms.helper import FormHelper
 from tbxforms.layout import (
     Fieldset,
@@ -9,14 +10,7 @@ from tbxforms.layout import (
 )
 
 
-class BaseForm(forms.Form):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.helper = FormHelper(self)
-
-
-class CheckboxForm(BaseForm):
-
+class CheckboxForm(BaseForm, forms.Form):
     accept = forms.BooleanField(
         label="I accept the terms of service",
         help_text="Please read the terms of service.",
@@ -24,8 +18,7 @@ class CheckboxForm(BaseForm):
     )
 
 
-class CheckboxesForm(BaseForm):
-
+class CheckboxesForm(BaseForm, forms.Form):
     method = forms.ChoiceField(
         choices=(
             ("email", "Email"),
@@ -39,8 +32,7 @@ class CheckboxesForm(BaseForm):
     )
 
 
-class CheckboxesChoiceForm(BaseForm):
-
+class CheckboxesChoiceForm(BaseForm, forms.Form):
     METHODS = (
         Choice("email", "Email"),
         Choice(
@@ -60,8 +52,7 @@ class CheckboxesChoiceForm(BaseForm):
     )
 
 
-class DateInputForm(BaseForm):
-
+class DateInputForm(BaseForm, forms.Form):
     date = DateInputField(
         label="When was your passport issued?",
         help_text="For example, 12 11 2007",
@@ -69,8 +60,7 @@ class DateInputForm(BaseForm):
     )
 
 
-class FileUploadForm(BaseForm):
-
+class FileUploadForm(BaseForm, forms.Form):
     file = forms.FileField(
         label="Upload a file",
         help_text="Select the CSV file to upload.",
@@ -80,8 +70,7 @@ class FileUploadForm(BaseForm):
     )
 
 
-class RadiosForm(BaseForm):
-
+class RadiosForm(BaseForm, forms.Form):
     method = forms.ChoiceField(
         choices=(
             ("email", "Email"),
@@ -95,8 +84,7 @@ class RadiosForm(BaseForm):
     )
 
 
-class RadiosChoiceForm(BaseForm):
-
+class RadiosChoiceForm(BaseForm, forms.Form):
     METHODS = (
         Choice("email", "Email", hint="Do not give a work email address"),
         Choice("phone", "Phone", divider="Or"),
@@ -112,8 +100,7 @@ class RadiosChoiceForm(BaseForm):
     )
 
 
-class SelectForm(BaseForm):
-
+class SelectForm(BaseForm, forms.Form):
     method = forms.ChoiceField(
         choices=(
             ("", "Choose"),
@@ -128,8 +115,7 @@ class SelectForm(BaseForm):
     )
 
 
-class TextInputForm(BaseForm):
-
+class TextInputForm(BaseForm, forms.Form):
     name = forms.CharField(
         label="Name",
         help_text="Help text",
@@ -137,8 +123,7 @@ class TextInputForm(BaseForm):
     )
 
 
-class TextareaForm(BaseForm):
-
+class TextareaForm(BaseForm, forms.Form):
     description = forms.CharField(
         label="Description",
         widget=forms.Textarea,
@@ -147,14 +132,14 @@ class TextareaForm(BaseForm):
     )
 
 
-class FieldsetForm(forms.Form):
-
+class FieldsetForm(BaseForm, forms.Form):
     name = forms.CharField(label="Name")
     email = forms.CharField(label="Email")
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.helper = FormHelper()
-        self.helper.layout = Layout(
-            Fieldset("name", "email", legend="Contact")
+    @property
+    def helper(self) -> FormHelper:
+        fh = super().helper
+        fh.layout = Layout(
+            Fieldset("name", "email", legend="Contact"),
         )
+        return fh

--- a/tests/helpers/__snapshots__/test_form_helper/test_default_label_size.html
+++ b/tests/helpers/__snapshots__/test_form_helper/test_default_label_size.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_name" class="tbxforms-form-group">
         <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
         <span id="id_name_hint" class="tbxforms-hint">Help text</span>
@@ -6,6 +6,7 @@
                name="name"
                aria-describedby="id_name_hint"
                class="tbxforms-input tbxforms-input--text"
+               required="required"
                id="id_name">
     </div>
 </form>

--- a/tests/helpers/__snapshots__/test_form_helper/test_default_label_size.html
+++ b/tests/helpers/__snapshots__/test_form_helper/test_default_label_size.html
@@ -1,6 +1,6 @@
 <form class="tbxforms" method="post">
     <div id="div_id_name" class="tbxforms-form-group">
-        <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
+        <label for="id_name" class="tbxforms-label tbxforms-label--s">Name</label>
         <span id="id_name_hint" class="tbxforms-hint">Help text</span>
         <input type="text"
                name="name"

--- a/tests/helpers/__snapshots__/test_form_helper/test_default_legend_size.html
+++ b/tests/helpers/__snapshots__/test_form_helper/test_default_legend_size.html
@@ -1,7 +1,7 @@
 <form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--s">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select all options that are relevant to you.</span>
             <div class="tbxforms-checkboxes">
                 <div class="tbxforms-checkboxes__item">

--- a/tests/helpers/__snapshots__/test_form_helper/test_default_legend_size.html
+++ b/tests/helpers/__snapshots__/test_form_helper/test_default_legend_size.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
             <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>

--- a/tests/helpers/__snapshots__/test_form_helper/test_override_default_label_size.html
+++ b/tests/helpers/__snapshots__/test_form_helper/test_override_default_label_size.html
@@ -1,6 +1,6 @@
 <form class="tbxforms" method="post">
     <div id="div_id_name" class="tbxforms-form-group">
-        <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
+        <label for="id_name" class="tbxforms-label tbxforms-label--l">Name</label>
         <span id="id_name_hint" class="tbxforms-hint">Help text</span>
         <input type="text"
                name="name"

--- a/tests/helpers/__snapshots__/test_form_helper/test_override_default_label_size.html
+++ b/tests/helpers/__snapshots__/test_form_helper/test_override_default_label_size.html
@@ -1,11 +1,12 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_name" class="tbxforms-form-group">
-        <label for="id_name" class="tbxforms-label tbxforms-label--l">Name</label>
+        <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
         <span id="id_name_hint" class="tbxforms-hint">Help text</span>
         <input type="text"
                name="name"
                aria-describedby="id_name_hint"
                class="tbxforms-input tbxforms-input--text"
+               required="required"
                id="id_name">
     </div>
 </form>

--- a/tests/helpers/__snapshots__/test_form_helper/test_override_default_legend_size.html
+++ b/tests/helpers/__snapshots__/test_form_helper/test_override_default_legend_size.html
@@ -1,7 +1,7 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--l">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select all options that are relevant to you.</span>
             <div class="tbxforms-checkboxes">
                 <div class="tbxforms-checkboxes__item">

--- a/tests/helpers/__snapshots__/test_form_helper/test_override_default_legend_size.html
+++ b/tests/helpers/__snapshots__/test_form_helper/test_override_default_legend_size.html
@@ -1,7 +1,7 @@
 <form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--l">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select all options that are relevant to you.</span>
             <div class="tbxforms-checkboxes">
                 <div class="tbxforms-checkboxes__item">

--- a/tests/helpers/test_form_helper.py
+++ b/tests/helpers/test_form_helper.py
@@ -2,7 +2,6 @@
 Tests to verify text fields are rendered correctly.
 
 """
-from tbxforms.helper import FormHelper
 from tbxforms.layout import (
     Field,
     Layout,
@@ -18,7 +17,6 @@ from tests.utils import render_form
 def test_default_label_size(snapshot_html):
     """Verify a default label size can set for fields."""
     form = TextInputForm()
-    form.helper = FormHelper(form)
     form.helper.label_size = Size.MEDIUM
     assert render_form(form) == snapshot_html
 
@@ -26,7 +24,6 @@ def test_default_label_size(snapshot_html):
 def test_override_default_label_size(snapshot_html):
     """Verify a default label size can be overridden on the field."""
     form = TextInputForm()
-    form.helper = FormHelper()
     form.helper.label_size = Size.MEDIUM
     form.helper.layout = Layout(Field.text("name", label_size=Size.LARGE))
     assert render_form(form) == snapshot_html
@@ -35,7 +32,6 @@ def test_override_default_label_size(snapshot_html):
 def test_default_legend_size(snapshot_html):
     """Verify a default legend size can set for fields."""
     form = CheckboxesForm()
-    form.helper = FormHelper(form)
     form.helper.legend_size = Size.MEDIUM
     assert render_form(form) == snapshot_html
 
@@ -43,7 +39,6 @@ def test_default_legend_size(snapshot_html):
 def test_override_default_legend_size(snapshot_html):
     """Verify a default legend size can be overridden on the field."""
     form = CheckboxesForm()
-    form.helper = FormHelper()
     form.helper.legend_size = Size.MEDIUM
     form.helper.layout = Layout(
         Field.checkboxes("method", legend_size=Size.LARGE)

--- a/tests/helpers/test_form_helper.py
+++ b/tests/helpers/test_form_helper.py
@@ -17,14 +17,14 @@ from tests.utils import render_form
 def test_default_label_size(snapshot_html):
     """Verify a default label size can set for fields."""
     form = TextInputForm()
-    form.helper.label_size = Size.MEDIUM
+    form.helper.label_size = Size.SMALL
     assert render_form(form) == snapshot_html
 
 
 def test_override_default_label_size(snapshot_html):
     """Verify a default label size can be overridden on the field."""
     form = TextInputForm()
-    form.helper.label_size = Size.MEDIUM
+    form.helper.label_size = Size.SMALL
     form.helper.layout = Layout(Field.text("name", label_size=Size.LARGE))
     assert render_form(form) == snapshot_html
 
@@ -32,14 +32,14 @@ def test_override_default_label_size(snapshot_html):
 def test_default_legend_size(snapshot_html):
     """Verify a default legend size can set for fields."""
     form = CheckboxesForm()
-    form.helper.legend_size = Size.MEDIUM
+    form.helper.legend_size = Size.SMALL
     assert render_form(form) == snapshot_html
 
 
 def test_override_default_legend_size(snapshot_html):
     """Verify a default legend size can be overridden on the field."""
     form = CheckboxesForm()
-    form.helper.legend_size = Size.MEDIUM
+    form.helper.legend_size = Size.SMALL
     form.helper.layout = Layout(
         Field.checkboxes("method", legend_size=Size.LARGE)
     )

--- a/tests/layout/__snapshots__/test_checkbox/test_checkbox_size.html
+++ b/tests/layout/__snapshots__/test_checkbox/test_checkbox_size.html
@@ -1,7 +1,7 @@
 <form class="tbxforms" method="post">
     <div id="div_id_accept" class="tbxforms-form-group">
         <span id="id_accept_hint" class="tbxforms-hint">Please read the terms of service.</span>
-        <div class="tbxforms-checkboxes">
+        <div class="tbxforms-checkboxes tbxforms-checkboxes--small">
             <div class="tbxforms-checkboxes__item">
                 <input type="checkbox"
                        name="accept"

--- a/tests/layout/__snapshots__/test_checkbox/test_checkbox_size.html
+++ b/tests/layout/__snapshots__/test_checkbox/test_checkbox_size.html
@@ -1,12 +1,13 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_accept" class="tbxforms-form-group">
         <span id="id_accept_hint" class="tbxforms-hint">Please read the terms of service.</span>
-        <div class="tbxforms-checkboxes tbxforms-checkboxes--small">
+        <div class="tbxforms-checkboxes">
             <div class="tbxforms-checkboxes__item">
                 <input type="checkbox"
                        name="accept"
                        aria-describedby="id_accept_hint"
                        class="tbxforms-checkboxes__input"
+                       required="required"
                        id="id_accept">
                 <label class="tbxforms-label tbxforms-checkboxes__label" for="id_accept">I accept the terms of service</label>
             </div>

--- a/tests/layout/__snapshots__/test_checkbox/test_initial_attributes.html
+++ b/tests/layout/__snapshots__/test_checkbox/test_initial_attributes.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_accept" class="tbxforms-form-group">
         <span id="id_accept_hint" class="tbxforms-hint">Please read the terms of service.</span>
         <div class="tbxforms-checkboxes">
@@ -7,6 +7,7 @@
                        name="accept"
                        aria-describedby="id_accept_hint"
                        class="tbxforms-checkboxes__input"
+                       required="required"
                        id="id_accept"
                        checked>
                 <label class="tbxforms-label tbxforms-checkboxes__label" for="id_accept">I accept the terms of service</label>

--- a/tests/layout/__snapshots__/test_checkbox/test_no_help_text.html
+++ b/tests/layout/__snapshots__/test_checkbox/test_no_help_text.html
@@ -1,10 +1,11 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_accept" class="tbxforms-form-group">
         <div class="tbxforms-checkboxes">
             <div class="tbxforms-checkboxes__item">
                 <input type="checkbox"
                        name="accept"
                        class="tbxforms-checkboxes__input"
+                       required="required"
                        id="id_accept">
                 <label class="tbxforms-label tbxforms-checkboxes__label" for="id_accept">I accept the terms of service</label>
             </div>

--- a/tests/layout/__snapshots__/test_checkbox/test_no_help_text_errors.html
+++ b/tests/layout/__snapshots__/test_checkbox/test_no_help_text_errors.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -24,6 +24,7 @@
                        name="accept"
                        aria-describedby="id_accept_1_error"
                        class="tbxforms-checkboxes__input"
+                       required="required"
                        id="id_accept">
                 <label class="tbxforms-label tbxforms-checkboxes__label" for="id_accept">I accept the terms of service</label>
             </div>

--- a/tests/layout/__snapshots__/test_checkbox/test_validation_error_attributes.html
+++ b/tests/layout/__snapshots__/test_checkbox/test_validation_error_attributes.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -25,6 +25,7 @@
                        name="accept"
                        aria-describedby="id_accept_1_error id_accept_hint"
                        class="tbxforms-checkboxes__input"
+                       required="required"
                        id="id_accept">
                 <label class="tbxforms-label tbxforms-checkboxes__label" for="id_accept">I accept the terms of service</label>
             </div>

--- a/tests/layout/__snapshots__/test_checkboxes/test_change_legend_size.html
+++ b/tests/layout/__snapshots__/test_checkboxes/test_change_legend_size.html
@@ -1,7 +1,7 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--l">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select all options that are relevant to you.</span>
             <div class="tbxforms-checkboxes">
                 <div class="tbxforms-checkboxes__item">

--- a/tests/layout/__snapshots__/test_checkboxes/test_change_legend_size.html
+++ b/tests/layout/__snapshots__/test_checkboxes/test_change_legend_size.html
@@ -1,7 +1,7 @@
 <form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--l">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select all options that are relevant to you.</span>
             <div class="tbxforms-checkboxes">
                 <div class="tbxforms-checkboxes__item">

--- a/tests/layout/__snapshots__/test_checkboxes/test_checkbox_size.html
+++ b/tests/layout/__snapshots__/test_checkboxes/test_checkbox_size.html
@@ -1,9 +1,9 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select all options that are relevant to you.</span>
-            <div class="tbxforms-checkboxes tbxforms-checkboxes--small">
+            <div class="tbxforms-checkboxes">
                 <div class="tbxforms-checkboxes__item">
                     <input type="checkbox"
                            name="method"

--- a/tests/layout/__snapshots__/test_checkboxes/test_checkbox_size.html
+++ b/tests/layout/__snapshots__/test_checkboxes/test_checkbox_size.html
@@ -3,7 +3,7 @@
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
             <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select all options that are relevant to you.</span>
-            <div class="tbxforms-checkboxes">
+            <div class="tbxforms-checkboxes tbxforms-checkboxes--small">
                 <div class="tbxforms-checkboxes__item">
                     <input type="checkbox"
                            name="method"

--- a/tests/layout/__snapshots__/test_checkboxes/test_choices.html
+++ b/tests/layout/__snapshots__/test_checkboxes/test_choices.html
@@ -1,7 +1,7 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select all options that are relevant to you.</span>
             <div class="tbxforms-checkboxes">
                 <div class="tbxforms-checkboxes__item">

--- a/tests/layout/__snapshots__/test_checkboxes/test_initial_attributes.html
+++ b/tests/layout/__snapshots__/test_checkboxes/test_initial_attributes.html
@@ -1,7 +1,7 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select all options that are relevant to you.</span>
             <div class="tbxforms-checkboxes">
                 <div class="tbxforms-checkboxes__item">

--- a/tests/layout/__snapshots__/test_checkboxes/test_no_help_text.html
+++ b/tests/layout/__snapshots__/test_checkboxes/test_no_help_text.html
@@ -1,7 +1,7 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset">
-            <legend class="tbxforms-fieldset__legend">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <div class="tbxforms-checkboxes">
                 <div class="tbxforms-checkboxes__item">
                     <input type="checkbox"

--- a/tests/layout/__snapshots__/test_checkboxes/test_no_help_text_errors.html
+++ b/tests/layout/__snapshots__/test_checkboxes/test_no_help_text_errors.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -16,7 +16,7 @@
     <div id="div_id_method"
          class="tbxforms-form-group tbxforms-form-group--error">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_1_error ">
-            <legend class="tbxforms-fieldset__legend">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_1_error" class="tbxforms-error-message">
                 <span class="tbxforms-visually-hidden">Error:</span> Enter the ways to contact you
             </span>

--- a/tests/layout/__snapshots__/test_checkboxes/test_no_legend.html
+++ b/tests/layout/__snapshots__/test_checkboxes/test_no_legend.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
             <span id="id_method_hint" class="tbxforms-hint">Select all options that are relevant to you.</span>

--- a/tests/layout/__snapshots__/test_checkboxes/test_show_legend_as_heading.html
+++ b/tests/layout/__snapshots__/test_checkboxes/test_show_legend_as_heading.html
@@ -1,9 +1,7 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend">
-                <h1 class="tbxforms-fieldset__heading">How would you like to be contacted?</h1>
-            </legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select all options that are relevant to you.</span>
             <div class="tbxforms-checkboxes">
                 <div class="tbxforms-checkboxes__item">

--- a/tests/layout/__snapshots__/test_checkboxes/test_show_legend_as_heading.html
+++ b/tests/layout/__snapshots__/test_checkboxes/test_show_legend_as_heading.html
@@ -1,7 +1,9 @@
 <form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">
+                <h1 class="tbxforms-fieldset__heading">How would you like to be contacted?</h1>
+            </legend>
             <span id="id_method_hint" class="tbxforms-hint">Select all options that are relevant to you.</span>
             <div class="tbxforms-checkboxes">
                 <div class="tbxforms-checkboxes__item">

--- a/tests/layout/__snapshots__/test_checkboxes/test_validation_error_attributes.html
+++ b/tests/layout/__snapshots__/test_checkboxes/test_validation_error_attributes.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -17,7 +17,7 @@
          class="tbxforms-form-group tbxforms-form-group--error">
         <fieldset class="tbxforms-fieldset"
                   aria-describedby="id_method_1_error id_method_hint">
-            <legend class="tbxforms-fieldset__legend">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_1_error" class="tbxforms-error-message">
                 <span class="tbxforms-visually-hidden">Error:</span> Enter the ways to contact you
             </span>

--- a/tests/layout/__snapshots__/test_date_input/test_field_error_attributes.html
+++ b/tests/layout/__snapshots__/test_date_input/test_field_error_attributes.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -17,7 +17,7 @@
          class="tbxforms-form-group tbxforms-form-group--error">
         <fieldset class="tbxforms-fieldset"
                   aria-describedby="id_date_1_error id_date_hint">
-            <legend class="tbxforms-fieldset__legend">When was your passport issued?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">When was your passport issued?</legend>
             <span id="id_date_1_error" class="tbxforms-error-message">
                 <span class="tbxforms-visually-hidden">Error:</span> Enter the day, month, and year.
             </span>
@@ -31,6 +31,7 @@
                                class="tbxforms-input tbxforms-input--text tbxforms-date-input__input tbxforms-input--width-2 tbxforms-input--error"
                                pattern="[0-9]*"
                                inputmode="numeric"
+                               required="required"
                                id="id_date_0">
                     </div>
                 </div>
@@ -42,6 +43,7 @@
                                class="tbxforms-input tbxforms-input--text tbxforms-date-input__input tbxforms-input--width-2 tbxforms-input--error"
                                pattern="[0-9]*"
                                inputmode="numeric"
+                               required="required"
                                id="id_date_1">
                     </div>
                 </div>
@@ -53,6 +55,7 @@
                                class="tbxforms-input tbxforms-input--text tbxforms-date-input__input tbxforms-input--width-4 tbxforms-input--error"
                                pattern="[0-9]*"
                                inputmode="numeric"
+                               required="required"
                                id="id_date_2">
                     </div>
                 </div>

--- a/tests/layout/__snapshots__/test_date_input/test_initial_attributes.html
+++ b/tests/layout/__snapshots__/test_date_input/test_initial_attributes.html
@@ -1,7 +1,7 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_date" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_date_hint">
-            <legend class="tbxforms-fieldset__legend">When was your passport issued?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">When was your passport issued?</legend>
             <span id="id_date_hint" class="tbxforms-hint">For example, 12 11 2007</span>
             <div class="tbxforms-date-input" id="id_date">
                 <div class="tbxforms-date-input__item">
@@ -13,6 +13,7 @@
                                class="tbxforms-input tbxforms-input--text tbxforms-date-input__input tbxforms-input--width-2"
                                pattern="[0-9]*"
                                inputmode="numeric"
+                               required="required"
                                id="id_date_0">
                     </div>
                 </div>
@@ -25,6 +26,7 @@
                                class="tbxforms-input tbxforms-input--text tbxforms-date-input__input tbxforms-input--width-2"
                                pattern="[0-9]*"
                                inputmode="numeric"
+                               required="required"
                                id="id_date_1">
                     </div>
                 </div>
@@ -37,6 +39,7 @@
                                class="tbxforms-input tbxforms-input--text tbxforms-date-input__input tbxforms-input--width-4"
                                pattern="[0-9]*"
                                inputmode="numeric"
+                               required="required"
                                id="id_date_2">
                     </div>
                 </div>

--- a/tests/layout/__snapshots__/test_date_input/test_subfield_error_attributes.html
+++ b/tests/layout/__snapshots__/test_date_input/test_subfield_error_attributes.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -21,7 +21,7 @@
          class="tbxforms-form-group tbxforms-form-group--error">
         <fieldset class="tbxforms-fieldset"
                   aria-describedby="id_date_1_error id_date_2_error id_date_hint">
-            <legend class="tbxforms-fieldset__legend">When was your passport issued?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">When was your passport issued?</legend>
             <span id="id_date_1_error" class="tbxforms-error-message">
                 <span class="tbxforms-visually-hidden">Error:</span> Enter a valid date
             </span>
@@ -40,6 +40,7 @@
                                pattern="[0-9]*"
                                inputmode="numeric"
                                aria-describedby="id_date_1_error"
+                               required="required"
                                id="id_date_0">
                     </div>
                 </div>
@@ -52,6 +53,7 @@
                                class="tbxforms-input tbxforms-input--text tbxforms-date-input__input tbxforms-input--width-2"
                                pattern="[0-9]*"
                                inputmode="numeric"
+                               required="required"
                                id="id_date_1">
                     </div>
                 </div>
@@ -64,6 +66,7 @@
                                pattern="[0-9]*"
                                inputmode="numeric"
                                aria-describedby="id_date_2_error"
+                               required="required"
                                id="id_date_2">
                     </div>
                 </div>

--- a/tests/layout/__snapshots__/test_fieldset/test_attribute.html
+++ b/tests/layout/__snapshots__/test_fieldset/test_attribute.html
@@ -1,4 +1,21 @@
 <form class="tbxforms" method="post">
-    <fieldset class="tbxforms-form-group tbxforms-fieldset" key="value">
+    <fieldset class="tbxforms-form-group tbxforms-fieldset">
+        <legend class="tbxforms-fieldset__legend">Contact</legend>
+        <div id="div_id_name" class="tbxforms-form-group">
+            <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
+            <input type="text"
+                   name="name"
+                   class="tbxforms-input tbxforms-input--text"
+                   required="required"
+                   id="id_name">
+        </div>
+        <div id="div_id_email" class="tbxforms-form-group">
+            <label for="id_email" class="tbxforms-label tbxforms-label--m">Email</label>
+            <input type="text"
+                   name="email"
+                   class="tbxforms-input tbxforms-input--text"
+                   required="required"
+                   id="id_email">
+        </div>
     </fieldset>
 </form>

--- a/tests/layout/__snapshots__/test_fieldset/test_attribute.html
+++ b/tests/layout/__snapshots__/test_fieldset/test_attribute.html
@@ -1,4 +1,21 @@
-<form method="post">
-    <fieldset class="tbxforms-form-group tbxforms-fieldset" key="value">
+<form class="tbxforms" method="post">
+    <fieldset class="tbxforms-form-group tbxforms-fieldset">
+        <legend class="tbxforms-fieldset__legend">Contact</legend>
+        <div id="div_id_name" class="tbxforms-form-group">
+            <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
+            <input type="text"
+                   name="name"
+                   class="tbxforms-input tbxforms-input--text"
+                   required="required"
+                   id="id_name">
+        </div>
+        <div id="div_id_email" class="tbxforms-form-group">
+            <label for="id_email" class="tbxforms-label tbxforms-label--m">Email</label>
+            <input type="text"
+                   name="email"
+                   class="tbxforms-input tbxforms-input--text"
+                   required="required"
+                   id="id_email">
+        </div>
     </fieldset>
 </form>

--- a/tests/layout/__snapshots__/test_fieldset/test_attribute.html
+++ b/tests/layout/__snapshots__/test_fieldset/test_attribute.html
@@ -1,21 +1,4 @@
 <form class="tbxforms" method="post">
-    <fieldset class="tbxforms-form-group tbxforms-fieldset">
-        <legend class="tbxforms-fieldset__legend">Contact</legend>
-        <div id="div_id_name" class="tbxforms-form-group">
-            <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
-            <input type="text"
-                   name="name"
-                   class="tbxforms-input tbxforms-input--text"
-                   required="required"
-                   id="id_name">
-        </div>
-        <div id="div_id_email" class="tbxforms-form-group">
-            <label for="id_email" class="tbxforms-label tbxforms-label--m">Email</label>
-            <input type="text"
-                   name="email"
-                   class="tbxforms-input tbxforms-input--text"
-                   required="required"
-                   id="id_email">
-        </div>
+    <fieldset class="tbxforms-form-group tbxforms-fieldset" key="value">
     </fieldset>
 </form>

--- a/tests/layout/__snapshots__/test_fieldset/test_basic_layout.html
+++ b/tests/layout/__snapshots__/test_fieldset/test_basic_layout.html
@@ -1,18 +1,20 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <fieldset class="tbxforms-form-group tbxforms-fieldset">
         <legend class="tbxforms-fieldset__legend">Contact</legend>
         <div id="div_id_name" class="tbxforms-form-group">
-            <label for="id_name" class="tbxforms-label">Name</label>
+            <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
             <input type="text"
                    name="name"
                    class="tbxforms-input tbxforms-input--text"
+                   required="required"
                    id="id_name">
         </div>
         <div id="div_id_email" class="tbxforms-form-group">
-            <label for="id_email" class="tbxforms-label">Email</label>
+            <label for="id_email" class="tbxforms-label tbxforms-label--m">Email</label>
             <input type="text"
                    name="email"
                    class="tbxforms-input tbxforms-input--text"
+                   required="required"
                    id="id_email">
         </div>
     </fieldset>

--- a/tests/layout/__snapshots__/test_fieldset/test_change_legend_size.html
+++ b/tests/layout/__snapshots__/test_fieldset/test_change_legend_size.html
@@ -1,6 +1,6 @@
 <form class="tbxforms" method="post">
     <fieldset class="tbxforms-form-group tbxforms-fieldset">
-        <legend class="tbxforms-fieldset__legend">Contact</legend>
+        <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--l">Contact</legend>
         <div id="div_id_name" class="tbxforms-form-group">
             <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
             <input type="text"

--- a/tests/layout/__snapshots__/test_fieldset/test_change_legend_size.html
+++ b/tests/layout/__snapshots__/test_fieldset/test_change_legend_size.html
@@ -1,6 +1,6 @@
 <form class="tbxforms" method="post">
     <fieldset class="tbxforms-form-group tbxforms-fieldset">
-        <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--l">Contact</legend>
+        <legend class="tbxforms-fieldset__legend">Contact</legend>
         <div id="div_id_name" class="tbxforms-form-group">
             <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
             <input type="text"

--- a/tests/layout/__snapshots__/test_fieldset/test_change_legend_size.html
+++ b/tests/layout/__snapshots__/test_fieldset/test_change_legend_size.html
@@ -1,18 +1,20 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <fieldset class="tbxforms-form-group tbxforms-fieldset">
-        <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--l">Contact</legend>
+        <legend class="tbxforms-fieldset__legend">Contact</legend>
         <div id="div_id_name" class="tbxforms-form-group">
-            <label for="id_name" class="tbxforms-label">Name</label>
+            <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
             <input type="text"
                    name="name"
                    class="tbxforms-input tbxforms-input--text"
+                   required="required"
                    id="id_name">
         </div>
         <div id="div_id_email" class="tbxforms-form-group">
-            <label for="id_email" class="tbxforms-label">Email</label>
+            <label for="id_email" class="tbxforms-label tbxforms-label--m">Email</label>
             <input type="text"
                    name="email"
                    class="tbxforms-input tbxforms-input--text"
+                   required="required"
                    id="id_email">
         </div>
     </fieldset>

--- a/tests/layout/__snapshots__/test_fieldset/test_css_class.html
+++ b/tests/layout/__snapshots__/test_fieldset/test_css_class.html
@@ -1,4 +1,21 @@
-<form method="post">
-    <fieldset class="tbxforms-form-group tbxforms-fieldset extra-css-class">
+<form class="tbxforms" method="post">
+    <fieldset class="tbxforms-form-group tbxforms-fieldset">
+        <legend class="tbxforms-fieldset__legend">Contact</legend>
+        <div id="div_id_name" class="tbxforms-form-group">
+            <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
+            <input type="text"
+                   name="name"
+                   class="tbxforms-input tbxforms-input--text"
+                   required="required"
+                   id="id_name">
+        </div>
+        <div id="div_id_email" class="tbxforms-form-group">
+            <label for="id_email" class="tbxforms-label tbxforms-label--m">Email</label>
+            <input type="text"
+                   name="email"
+                   class="tbxforms-input tbxforms-input--text"
+                   required="required"
+                   id="id_email">
+        </div>
     </fieldset>
 </form>

--- a/tests/layout/__snapshots__/test_fieldset/test_css_id.html
+++ b/tests/layout/__snapshots__/test_fieldset/test_css_id.html
@@ -1,4 +1,21 @@
-<form method="post">
-    <fieldset id="new_id" class="tbxforms-form-group tbxforms-fieldset">
+<form class="tbxforms" method="post">
+    <fieldset class="tbxforms-form-group tbxforms-fieldset">
+        <legend class="tbxforms-fieldset__legend">Contact</legend>
+        <div id="div_id_name" class="tbxforms-form-group">
+            <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
+            <input type="text"
+                   name="name"
+                   class="tbxforms-input tbxforms-input--text"
+                   required="required"
+                   id="id_name">
+        </div>
+        <div id="div_id_email" class="tbxforms-form-group">
+            <label for="id_email" class="tbxforms-label tbxforms-label--m">Email</label>
+            <input type="text"
+                   name="email"
+                   class="tbxforms-input tbxforms-input--text"
+                   required="required"
+                   id="id_email">
+        </div>
     </fieldset>
 </form>

--- a/tests/layout/__snapshots__/test_fieldset/test_show_legend_as_heading.html
+++ b/tests/layout/__snapshots__/test_fieldset/test_show_legend_as_heading.html
@@ -1,6 +1,8 @@
 <form class="tbxforms" method="post">
     <fieldset class="tbxforms-form-group tbxforms-fieldset">
-        <legend class="tbxforms-fieldset__legend">Contact</legend>
+        <legend class="tbxforms-fieldset__legend">
+            <h1 class="tbxforms-fieldset__heading">Contact</h1>
+        </legend>
         <div id="div_id_name" class="tbxforms-form-group">
             <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
             <input type="text"

--- a/tests/layout/__snapshots__/test_fieldset/test_show_legend_as_heading.html
+++ b/tests/layout/__snapshots__/test_fieldset/test_show_legend_as_heading.html
@@ -1,8 +1,6 @@
 <form class="tbxforms" method="post">
     <fieldset class="tbxforms-form-group tbxforms-fieldset">
-        <legend class="tbxforms-fieldset__legend">
-            <h1 class="tbxforms-fieldset__heading">Contact</h1>
-        </legend>
+        <legend class="tbxforms-fieldset__legend">Contact</legend>
         <div id="div_id_name" class="tbxforms-form-group">
             <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
             <input type="text"

--- a/tests/layout/__snapshots__/test_fieldset/test_show_legend_as_heading.html
+++ b/tests/layout/__snapshots__/test_fieldset/test_show_legend_as_heading.html
@@ -1,20 +1,20 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <fieldset class="tbxforms-form-group tbxforms-fieldset">
-        <legend class="tbxforms-fieldset__legend">
-            <h1 class="tbxforms-fieldset__heading">Contact</h1>
-        </legend>
+        <legend class="tbxforms-fieldset__legend">Contact</legend>
         <div id="div_id_name" class="tbxforms-form-group">
-            <label for="id_name" class="tbxforms-label">Name</label>
+            <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
             <input type="text"
                    name="name"
                    class="tbxforms-input tbxforms-input--text"
+                   required="required"
                    id="id_name">
         </div>
         <div id="div_id_email" class="tbxforms-form-group">
-            <label for="id_email" class="tbxforms-label">Email</label>
+            <label for="id_email" class="tbxforms-label tbxforms-label--m">Email</label>
             <input type="text"
                    name="email"
                    class="tbxforms-input tbxforms-input--text"
+                   required="required"
                    id="id_email">
         </div>
     </fieldset>

--- a/tests/layout/__snapshots__/test_file_upload/test_change_label_size.html
+++ b/tests/layout/__snapshots__/test_file_upload/test_change_label_size.html
@@ -1,11 +1,12 @@
-<form method="post"  enctype="multipart/form-data">
+<form class="tbxforms" method="post"  enctype="multipart/form-data">
     <div id="div_id_file" class="tbxforms-form-group">
-        <label for="id_file" class="tbxforms-label tbxforms-label--l">Upload a file</label>
+        <label for="id_file" class="tbxforms-label tbxforms-label--m">Upload a file</label>
         <span id="id_file_hint" class="tbxforms-hint">Select the CSV file to upload.</span>
         <input type="file"
                name="file"
                aria-describedby="id_file_hint"
                class="tbxforms-file-upload"
+               required="required"
                id="id_file">
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_file_upload/test_change_label_size.html
+++ b/tests/layout/__snapshots__/test_file_upload/test_change_label_size.html
@@ -1,6 +1,6 @@
 <form class="tbxforms" method="post"  enctype="multipart/form-data">
     <div id="div_id_file" class="tbxforms-form-group">
-        <label for="id_file" class="tbxforms-label tbxforms-label--l">Upload a file</label>
+        <label for="id_file" class="tbxforms-label l">Upload a file</label>
         <span id="id_file_hint" class="tbxforms-hint">Select the CSV file to upload.</span>
         <input type="file"
                name="file"

--- a/tests/layout/__snapshots__/test_file_upload/test_change_label_size.html
+++ b/tests/layout/__snapshots__/test_file_upload/test_change_label_size.html
@@ -1,6 +1,6 @@
 <form class="tbxforms" method="post"  enctype="multipart/form-data">
     <div id="div_id_file" class="tbxforms-form-group">
-        <label for="id_file" class="tbxforms-label tbxforms-label--m">Upload a file</label>
+        <label for="id_file" class="tbxforms-label tbxforms-label--l">Upload a file</label>
         <span id="id_file_hint" class="tbxforms-hint">Select the CSV file to upload.</span>
         <input type="file"
                name="file"

--- a/tests/layout/__snapshots__/test_file_upload/test_initial_attributes.html
+++ b/tests/layout/__snapshots__/test_file_upload/test_initial_attributes.html
@@ -1,11 +1,12 @@
-<form method="post"  enctype="multipart/form-data">
+<form class="tbxforms" method="post"  enctype="multipart/form-data">
     <div id="div_id_file" class="tbxforms-form-group">
-        <label for="id_file" class="tbxforms-label">Upload a file</label>
+        <label for="id_file" class="tbxforms-label tbxforms-label--m">Upload a file</label>
         <span id="id_file_hint" class="tbxforms-hint">Select the CSV file to upload.</span>
         <input type="file"
                name="file"
                aria-describedby="id_file_hint"
                class="tbxforms-file-upload"
+               required="required"
                id="id_file">
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_file_upload/test_no_help_text.html
+++ b/tests/layout/__snapshots__/test_file_upload/test_no_help_text.html
@@ -1,6 +1,10 @@
-<form method="post"  enctype="multipart/form-data">
+<form class="tbxforms" method="post"  enctype="multipart/form-data">
     <div id="div_id_file" class="tbxforms-form-group">
-        <label for="id_file" class="tbxforms-label">Upload a file</label>
-        <input type="file" name="file" class="tbxforms-file-upload" id="id_file">
+        <label for="id_file" class="tbxforms-label tbxforms-label--m">Upload a file</label>
+        <input type="file"
+               name="file"
+               class="tbxforms-file-upload"
+               required="required"
+               id="id_file">
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_file_upload/test_no_help_text_errors.html
+++ b/tests/layout/__snapshots__/test_file_upload/test_no_help_text_errors.html
@@ -1,4 +1,4 @@
-<form method="post"  enctype="multipart/form-data">
+<form class="tbxforms" method="post"  enctype="multipart/form-data">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -14,7 +14,7 @@
     </div>
     <div id="div_id_file"
          class="tbxforms-form-group tbxforms-form-group--error">
-        <label for="id_file" class="tbxforms-label">Upload a file</label>
+        <label for="id_file" class="tbxforms-label tbxforms-label--m">Upload a file</label>
         <span id="id_file_1_error" class="tbxforms-error-message">
             <span class="tbxforms-visually-hidden">Error:</span> Select the CSV file you exported from the spreadsheet
         </span>
@@ -22,6 +22,7 @@
                name="file"
                aria-describedby="id_file_1_error"
                class="tbxforms-file-upload tbxforms-file-upload--error"
+               required="required"
                id="id_file">
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_file_upload/test_no_label.html
+++ b/tests/layout/__snapshots__/test_file_upload/test_no_label.html
@@ -1,10 +1,11 @@
-<form method="post"  enctype="multipart/form-data">
+<form class="tbxforms" method="post"  enctype="multipart/form-data">
     <div id="div_id_file" class="tbxforms-form-group">
         <span id="id_file_hint" class="tbxforms-hint">Select the CSV file to upload.</span>
         <input type="file"
                name="file"
                aria-describedby="id_file_hint"
                class="tbxforms-file-upload"
+               required="required"
                id="id_file">
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_file_upload/test_show_label_as_heading.html
+++ b/tests/layout/__snapshots__/test_file_upload/test_show_label_as_heading.html
@@ -1,6 +1,8 @@
 <form class="tbxforms" method="post"  enctype="multipart/form-data">
     <div id="div_id_file" class="tbxforms-form-group">
-        <label for="id_file" class="tbxforms-label tbxforms-label--m">Upload a file</label>
+        <h1 class="tbxforms-label-wrapper">
+            <label for="id_file" class="tbxforms-label tbxforms-label--m">Upload a file</label>
+        </h1>
         <span id="id_file_hint" class="tbxforms-hint">Select the CSV file to upload.</span>
         <input type="file"
                name="file"

--- a/tests/layout/__snapshots__/test_file_upload/test_show_label_as_heading.html
+++ b/tests/layout/__snapshots__/test_file_upload/test_show_label_as_heading.html
@@ -1,13 +1,12 @@
-<form method="post"  enctype="multipart/form-data">
+<form class="tbxforms" method="post"  enctype="multipart/form-data">
     <div id="div_id_file" class="tbxforms-form-group">
-        <h1 class="tbxforms-label-wrapper">
-            <label for="id_file" class="tbxforms-label">Upload a file</label>
-        </h1>
+        <label for="id_file" class="tbxforms-label tbxforms-label--m">Upload a file</label>
         <span id="id_file_hint" class="tbxforms-hint">Select the CSV file to upload.</span>
         <input type="file"
                name="file"
                aria-describedby="id_file_hint"
                class="tbxforms-file-upload"
+               required="required"
                id="id_file">
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_file_upload/test_validation_error_attributes.html
+++ b/tests/layout/__snapshots__/test_file_upload/test_validation_error_attributes.html
@@ -1,4 +1,4 @@
-<form method="post"  enctype="multipart/form-data">
+<form class="tbxforms" method="post"  enctype="multipart/form-data">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -14,7 +14,7 @@
     </div>
     <div id="div_id_file"
          class="tbxforms-form-group tbxforms-form-group--error">
-        <label for="id_file" class="tbxforms-label">Upload a file</label>
+        <label for="id_file" class="tbxforms-label tbxforms-label--m">Upload a file</label>
         <span id="id_file_1_error" class="tbxforms-error-message">
             <span class="tbxforms-visually-hidden">Error:</span> Select the CSV file you exported from the spreadsheet
         </span>
@@ -23,6 +23,7 @@
                name="file"
                aria-describedby="id_file_1_error id_file_hint"
                class="tbxforms-file-upload tbxforms-file-upload--error"
+               required="required"
                id="id_file">
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_radios/test_change_legend_size.html
+++ b/tests/layout/__snapshots__/test_radios/test_change_legend_size.html
@@ -1,7 +1,7 @@
 <form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--l">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
             <div class="tbxforms-radios">
                 <div class="tbxforms-radios__item">

--- a/tests/layout/__snapshots__/test_radios/test_change_legend_size.html
+++ b/tests/layout/__snapshots__/test_radios/test_change_legend_size.html
@@ -1,7 +1,7 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--l">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
             <div class="tbxforms-radios">
                 <div class="tbxforms-radios__item">

--- a/tests/layout/__snapshots__/test_radios/test_choices.html
+++ b/tests/layout/__snapshots__/test_radios/test_choices.html
@@ -1,7 +1,7 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
             <div class="tbxforms-radios">
                 <div class="tbxforms-radios__item">

--- a/tests/layout/__snapshots__/test_radios/test_initial_attributes.html
+++ b/tests/layout/__snapshots__/test_radios/test_initial_attributes.html
@@ -1,7 +1,7 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
             <div class="tbxforms-radios">
                 <div class="tbxforms-radios__item">

--- a/tests/layout/__snapshots__/test_radios/test_inline.html
+++ b/tests/layout/__snapshots__/test_radios/test_inline.html
@@ -3,7 +3,7 @@
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
             <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
-            <div class="tbxforms-radios">
+            <div class="tbxforms-radios--inline">
                 <div class="tbxforms-radios__item">
                     <input type="radio"
                            name="method"

--- a/tests/layout/__snapshots__/test_radios/test_inline.html
+++ b/tests/layout/__snapshots__/test_radios/test_inline.html
@@ -1,9 +1,9 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
-            <div class="tbxforms-radios--inline">
+            <div class="tbxforms-radios">
                 <div class="tbxforms-radios__item">
                     <input type="radio"
                            name="method"

--- a/tests/layout/__snapshots__/test_radios/test_no_help_text.html
+++ b/tests/layout/__snapshots__/test_radios/test_no_help_text.html
@@ -1,7 +1,7 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset">
-            <legend class="tbxforms-fieldset__legend">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <div class="tbxforms-radios">
                 <div class="tbxforms-radios__item">
                     <input type="radio"

--- a/tests/layout/__snapshots__/test_radios/test_no_help_text_errors.html
+++ b/tests/layout/__snapshots__/test_radios/test_no_help_text_errors.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -16,7 +16,7 @@
     <div id="div_id_method"
          class="tbxforms-form-group tbxforms-form-group--error">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_1_error ">
-            <legend class="tbxforms-fieldset__legend">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_1_error" class="tbxforms-error-message">
                 <span class="tbxforms-visually-hidden">Error:</span> Enter the best way to contact you
             </span>

--- a/tests/layout/__snapshots__/test_radios/test_no_legend.html
+++ b/tests/layout/__snapshots__/test_radios/test_no_legend.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
             <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>

--- a/tests/layout/__snapshots__/test_radios/test_show_legend_as_heading.html
+++ b/tests/layout/__snapshots__/test_radios/test_show_legend_as_heading.html
@@ -1,9 +1,7 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend">
-                <h1 class="tbxforms-fieldset__heading">How would you like to be contacted?</h1>
-            </legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
             <div class="tbxforms-radios">
                 <div class="tbxforms-radios__item">

--- a/tests/layout/__snapshots__/test_radios/test_show_legend_as_heading.html
+++ b/tests/layout/__snapshots__/test_radios/test_show_legend_as_heading.html
@@ -1,7 +1,9 @@
 <form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">
+                <h1 class="tbxforms-fieldset__heading">How would you like to be contacted?</h1>
+            </legend>
             <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
             <div class="tbxforms-radios">
                 <div class="tbxforms-radios__item">

--- a/tests/layout/__snapshots__/test_radios/test_small.html
+++ b/tests/layout/__snapshots__/test_radios/test_small.html
@@ -1,9 +1,9 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
-            <legend class="tbxforms-fieldset__legend">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
-            <div class="tbxforms-radios tbxforms-radios--small">
+            <div class="tbxforms-radios">
                 <div class="tbxforms-radios__item">
                     <input type="radio"
                            name="method"

--- a/tests/layout/__snapshots__/test_radios/test_small.html
+++ b/tests/layout/__snapshots__/test_radios/test_small.html
@@ -3,7 +3,7 @@
         <fieldset class="tbxforms-fieldset"  aria-describedby="id_method_hint">
             <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
-            <div class="tbxforms-radios">
+            <div class="tbxforms-radios tbxforms-radios--small">
                 <div class="tbxforms-radios__item">
                     <input type="radio"
                            name="method"

--- a/tests/layout/__snapshots__/test_radios/test_validation_error_attributes.html
+++ b/tests/layout/__snapshots__/test_radios/test_validation_error_attributes.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -17,7 +17,7 @@
          class="tbxforms-form-group tbxforms-form-group--error">
         <fieldset class="tbxforms-fieldset"
                   aria-describedby="id_method_1_error id_method_hint">
-            <legend class="tbxforms-fieldset__legend">How would you like to be contacted?</legend>
+            <legend class="tbxforms-fieldset__legend tbxforms-fieldset__legend--m">How would you like to be contacted?</legend>
             <span id="id_method_1_error" class="tbxforms-error-message">
                 <span class="tbxforms-visually-hidden">Error:</span> Enter the best way to contact you
             </span>

--- a/tests/layout/__snapshots__/test_select/test_change_label_size.html
+++ b/tests/layout/__snapshots__/test_select/test_change_label_size.html
@@ -1,6 +1,6 @@
 <form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
-        <label for="id_method" class="tbxforms-label tbxforms-label--m">How would you like to be contacted?</label>
+        <label for="id_method" class="tbxforms-label tbxforms-label--l">How would you like to be contacted?</label>
         <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
         <select name="method"
                 aria-describedby="id_method_hint"

--- a/tests/layout/__snapshots__/test_select/test_change_label_size.html
+++ b/tests/layout/__snapshots__/test_select/test_change_label_size.html
@@ -1,10 +1,11 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
-        <label for="id_method" class="tbxforms-label tbxforms-label--l">How would you like to be contacted?</label>
+        <label for="id_method" class="tbxforms-label tbxforms-label--m">How would you like to be contacted?</label>
         <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
         <select name="method"
                 aria-describedby="id_method_hint"
                 class="tbxforms-select"
+                required="required"
                 id="id_method">
             <option value="" selected>Choose</option>
             <option value="email">Email</option>

--- a/tests/layout/__snapshots__/test_select/test_initial_attributes.html
+++ b/tests/layout/__snapshots__/test_select/test_initial_attributes.html
@@ -1,10 +1,11 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
-        <label for="id_method" class="tbxforms-label">How would you like to be contacted?</label>
+        <label for="id_method" class="tbxforms-label tbxforms-label--m">How would you like to be contacted?</label>
         <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
         <select name="method"
                 aria-describedby="id_method_hint"
                 class="tbxforms-select"
+                required="required"
                 id="id_method">
             <option value="">Choose</option>
             <option value="email" selected>Email</option>

--- a/tests/layout/__snapshots__/test_select/test_no_help_text.html
+++ b/tests/layout/__snapshots__/test_select/test_no_help_text.html
@@ -1,7 +1,10 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
-        <label for="id_method" class="tbxforms-label">How would you like to be contacted?</label>
-        <select name="method" class="tbxforms-select" id="id_method">
+        <label for="id_method" class="tbxforms-label tbxforms-label--m">How would you like to be contacted?</label>
+        <select name="method"
+                class="tbxforms-select"
+                required="required"
+                id="id_method">
             <option value="" selected>Choose</option>
             <option value="email">Email</option>
             <option value="phone">Phone</option>

--- a/tests/layout/__snapshots__/test_select/test_no_help_text_errors.html
+++ b/tests/layout/__snapshots__/test_select/test_no_help_text_errors.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -15,13 +15,14 @@
     </div>
     <div id="div_id_method"
          class="tbxforms-form-group tbxforms-form-group--error">
-        <label for="id_method" class="tbxforms-label">How would you like to be contacted?</label>
+        <label for="id_method" class="tbxforms-label tbxforms-label--m">How would you like to be contacted?</label>
         <span id="id_method_1_error" class="tbxforms-error-message">
             <span class="tbxforms-visually-hidden">Error:</span> Enter the best way to contact you
         </span>
         <select name="method"
                 aria-describedby="id_method_1_error"
                 class="tbxforms-select tbxforms-input--error"
+                required="required"
                 id="id_method">
             <option value="" selected>Choose</option>
             <option value="email">Email</option>

--- a/tests/layout/__snapshots__/test_select/test_no_label.html
+++ b/tests/layout/__snapshots__/test_select/test_no_label.html
@@ -1,9 +1,10 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
         <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
         <select name="method"
                 aria-describedby="id_method_hint"
                 class="tbxforms-select"
+                required="required"
                 id="id_method">
             <option value="" selected>Choose</option>
             <option value="email">Email</option>

--- a/tests/layout/__snapshots__/test_select/test_show_label_as_heading.html
+++ b/tests/layout/__snapshots__/test_select/test_show_label_as_heading.html
@@ -1,12 +1,11 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
-        <h1 class="tbxforms-label-wrapper">
-            <label for="id_method" class="tbxforms-label">How would you like to be contacted?</label>
-        </h1>
+        <label for="id_method" class="tbxforms-label tbxforms-label--m">How would you like to be contacted?</label>
         <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
         <select name="method"
                 aria-describedby="id_method_hint"
                 class="tbxforms-select"
+                required="required"
                 id="id_method">
             <option value="" selected>Choose</option>
             <option value="email">Email</option>

--- a/tests/layout/__snapshots__/test_select/test_show_label_as_heading.html
+++ b/tests/layout/__snapshots__/test_select/test_show_label_as_heading.html
@@ -1,6 +1,8 @@
 <form class="tbxforms" method="post">
     <div id="div_id_method" class="tbxforms-form-group">
-        <label for="id_method" class="tbxforms-label tbxforms-label--m">How would you like to be contacted?</label>
+        <h1 class="tbxforms-label-wrapper">
+            <label for="id_method" class="tbxforms-label tbxforms-label--m">How would you like to be contacted?</label>
+        </h1>
         <span id="id_method_hint" class="tbxforms-hint">Select the most convenient way to contact you.</span>
         <select name="method"
                 aria-describedby="id_method_hint"

--- a/tests/layout/__snapshots__/test_select/test_validation_error_attributes.html
+++ b/tests/layout/__snapshots__/test_select/test_validation_error_attributes.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -15,7 +15,7 @@
     </div>
     <div id="div_id_method"
          class="tbxforms-form-group tbxforms-form-group--error">
-        <label for="id_method" class="tbxforms-label">How would you like to be contacted?</label>
+        <label for="id_method" class="tbxforms-label tbxforms-label--m">How would you like to be contacted?</label>
         <span id="id_method_1_error" class="tbxforms-error-message">
             <span class="tbxforms-visually-hidden">Error:</span> Enter the best way to contact you
         </span>
@@ -23,6 +23,7 @@
         <select name="method"
                 aria-describedby="id_method_1_error id_method_hint"
                 class="tbxforms-select tbxforms-input--error"
+                required="required"
                 id="id_method">
             <option value="" selected>Choose</option>
             <option value="email">Email</option>

--- a/tests/layout/__snapshots__/test_text_input/test_change_label_size.html
+++ b/tests/layout/__snapshots__/test_text_input/test_change_label_size.html
@@ -1,6 +1,6 @@
 <form class="tbxforms" method="post">
     <div id="div_id_name" class="tbxforms-form-group">
-        <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
+        <label for="id_name" class="tbxforms-label tbxforms-label--l">Name</label>
         <span id="id_name_hint" class="tbxforms-hint">Help text</span>
         <input type="text"
                name="name"

--- a/tests/layout/__snapshots__/test_text_input/test_change_label_size.html
+++ b/tests/layout/__snapshots__/test_text_input/test_change_label_size.html
@@ -1,11 +1,12 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_name" class="tbxforms-form-group">
-        <label for="id_name" class="tbxforms-label tbxforms-label--l">Name</label>
+        <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
         <span id="id_name_hint" class="tbxforms-hint">Help text</span>
         <input type="text"
                name="name"
                aria-describedby="id_name_hint"
                class="tbxforms-input tbxforms-input--text"
+               required="required"
                id="id_name">
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_text_input/test_initial_attributes.html
+++ b/tests/layout/__snapshots__/test_text_input/test_initial_attributes.html
@@ -1,12 +1,13 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_name" class="tbxforms-form-group">
-        <label for="id_name" class="tbxforms-label">Name</label>
+        <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
         <span id="id_name_hint" class="tbxforms-hint">Help text</span>
         <input type="text"
                name="name"
                value="Field value"
                aria-describedby="id_name_hint"
                class="tbxforms-input tbxforms-input--text"
+               required="required"
                id="id_name">
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_text_input/test_no_help_text.html
+++ b/tests/layout/__snapshots__/test_text_input/test_no_help_text.html
@@ -1,9 +1,10 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_name" class="tbxforms-form-group">
-        <label for="id_name" class="tbxforms-label">Name</label>
+        <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
         <input type="text"
                name="name"
                class="tbxforms-input tbxforms-input--text"
+               required="required"
                id="id_name">
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_text_input/test_no_help_text_errors.html
+++ b/tests/layout/__snapshots__/test_text_input/test_no_help_text_errors.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -14,7 +14,7 @@
     </div>
     <div id="div_id_name"
          class="tbxforms-form-group tbxforms-form-group--error">
-        <label for="id_name" class="tbxforms-label">Name</label>
+        <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
         <span id="id_name_1_error" class="tbxforms-error-message">
             <span class="tbxforms-visually-hidden">Error:</span> Required error message
         </span>
@@ -22,6 +22,7 @@
                name="name"
                aria-describedby="id_name_1_error"
                class="tbxforms-input tbxforms-input--text tbxforms-input--error"
+               required="required"
                id="id_name">
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_text_input/test_no_label.html
+++ b/tests/layout/__snapshots__/test_text_input/test_no_label.html
@@ -1,10 +1,11 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_name" class="tbxforms-form-group">
         <span id="id_name_hint" class="tbxforms-hint">Help text</span>
         <input type="text"
                name="name"
                aria-describedby="id_name_hint"
                class="tbxforms-input tbxforms-input--text"
+               required="required"
                id="id_name">
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_text_input/test_show_label_as_heading.html
+++ b/tests/layout/__snapshots__/test_text_input/test_show_label_as_heading.html
@@ -1,13 +1,12 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_name" class="tbxforms-form-group">
-        <h1 class="tbxforms-label-wrapper">
-            <label for="id_name" class="tbxforms-label">Name</label>
-        </h1>
+        <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
         <span id="id_name_hint" class="tbxforms-hint">Help text</span>
         <input type="text"
                name="name"
                aria-describedby="id_name_hint"
                class="tbxforms-input tbxforms-input--text"
+               required="required"
                id="id_name">
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_text_input/test_show_label_as_heading.html
+++ b/tests/layout/__snapshots__/test_text_input/test_show_label_as_heading.html
@@ -1,6 +1,8 @@
 <form class="tbxforms" method="post">
     <div id="div_id_name" class="tbxforms-form-group">
-        <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
+        <h1 class="tbxforms-label-wrapper">
+            <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
+        </h1>
         <span id="id_name_hint" class="tbxforms-hint">Help text</span>
         <input type="text"
                name="name"

--- a/tests/layout/__snapshots__/test_text_input/test_validation_error_attributes.html
+++ b/tests/layout/__snapshots__/test_text_input/test_validation_error_attributes.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -14,7 +14,7 @@
     </div>
     <div id="div_id_name"
          class="tbxforms-form-group tbxforms-form-group--error">
-        <label for="id_name" class="tbxforms-label">Name</label>
+        <label for="id_name" class="tbxforms-label tbxforms-label--m">Name</label>
         <span id="id_name_1_error" class="tbxforms-error-message">
             <span class="tbxforms-visually-hidden">Error:</span> Required error message
         </span>
@@ -23,6 +23,7 @@
                name="name"
                aria-describedby="id_name_1_error id_name_hint"
                class="tbxforms-input tbxforms-input--text tbxforms-input--error"
+               required="required"
                id="id_name">
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_textarea/test_change_label_size.html
+++ b/tests/layout/__snapshots__/test_textarea/test_change_label_size.html
@@ -1,6 +1,6 @@
 <form class="tbxforms" method="post">
     <div id="div_id_description" class="tbxforms-form-group">
-        <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
+        <label for="id_description" class="tbxforms-label tbxforms-label--l">Description</label>
         <span id="id_description_hint" class="tbxforms-hint">Help text</span>
         <textarea name="description" cols="40" rows="10" aria-describedby="id_description_hint" class="tbxforms-textarea" required="required" id="id_description">
 </textarea>

--- a/tests/layout/__snapshots__/test_textarea/test_change_label_size.html
+++ b/tests/layout/__snapshots__/test_textarea/test_change_label_size.html
@@ -1,8 +1,8 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_description" class="tbxforms-form-group">
-        <label for="id_description" class="tbxforms-label tbxforms-label--l">Description</label>
+        <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
         <span id="id_description_hint" class="tbxforms-hint">Help text</span>
-        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_hint" class="tbxforms-textarea" id="id_description">
+        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_hint" class="tbxforms-textarea" required="required" id="id_description">
 </textarea>
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_textarea/test_character_count.html
+++ b/tests/layout/__snapshots__/test_textarea/test_character_count.html
@@ -1,15 +1,8 @@
-<form method="post">
-    <div class="tbxforms-character-count"
-         data-module="tbxforms-character-count"
-         data-maxlength="100">
-        <div id="div_id_description" class="tbxforms-form-group">
-            <label for="id_description" class="tbxforms-label">Description</label>
-            <span id="id_description_hint" class="tbxforms-hint">Help text</span>
-            <textarea name="description" cols="40" rows="10" class="tbxforms-textarea tbxforms-js-character-count" aria-describedby="id_description_hint id_description-info" id="id_description">
+<form class="tbxforms" method="post">
+    <div id="div_id_description" class="tbxforms-form-group">
+        <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
+        <span id="id_description_hint" class="tbxforms-hint">Help text</span>
+        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_hint" class="tbxforms-textarea" required="required" id="id_description">
 Field value</textarea>
-            <span id="id_description-info"
-                  class="tbxforms-hint tbxforms-character-count__message"
-                  aria-live="polite">You can enter up to 100 characters</span>
-        </div>
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_textarea/test_character_count.html
+++ b/tests/layout/__snapshots__/test_textarea/test_character_count.html
@@ -2,7 +2,7 @@
     <div id="div_id_description" class="tbxforms-form-group">
         <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
         <span id="id_description_hint" class="tbxforms-hint">Help text</span>
-        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_hint" class="tbxforms-textarea" required="required" id="id_description">
+        <textarea name="description" cols="40" rows="10" max-characters="100" aria-describedby="id_description_hint" class="tbxforms-textarea" required="required" id="id_description">
 Field value</textarea>
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_textarea/test_character_count.html
+++ b/tests/layout/__snapshots__/test_textarea/test_character_count.html
@@ -1,8 +1,15 @@
 <form class="tbxforms" method="post">
-    <div id="div_id_description" class="tbxforms-form-group">
-        <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
-        <span id="id_description_hint" class="tbxforms-hint">Help text</span>
-        <textarea name="description" cols="40" rows="10" max-characters="100" aria-describedby="id_description_hint" class="tbxforms-textarea" required="required" id="id_description">
+    <div class="tbxforms-character-count"
+         data-module="tbxforms-character-count"
+         data-maxlength="100">
+        <div id="div_id_description" class="tbxforms-form-group">
+            <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
+            <span id="id_description_hint" class="tbxforms-hint">Help text</span>
+            <textarea name="description" cols="40" rows="10" class="tbxforms-textarea tbxforms-js-character-count" aria-describedby="id_description_hint id_description-info" required="required" id="id_description">
 Field value</textarea>
+            <span id="id_description-info"
+                  class="tbxforms-hint tbxforms-character-count__message"
+                  aria-live="polite">You can enter up to 100 characters</span>
+        </div>
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_textarea/test_initial_attributes.html
+++ b/tests/layout/__snapshots__/test_textarea/test_initial_attributes.html
@@ -1,8 +1,8 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_description" class="tbxforms-form-group">
-        <label for="id_description" class="tbxforms-label">Description</label>
+        <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
         <span id="id_description_hint" class="tbxforms-hint">Help text</span>
-        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_hint" class="tbxforms-textarea" id="id_description">
+        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_hint" class="tbxforms-textarea" required="required" id="id_description">
 Field value</textarea>
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_textarea/test_no_help_text.html
+++ b/tests/layout/__snapshots__/test_textarea/test_no_help_text.html
@@ -1,7 +1,7 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_description" class="tbxforms-form-group">
-        <label for="id_description" class="tbxforms-label">Description</label>
-        <textarea name="description" cols="40" rows="10" class="tbxforms-textarea" id="id_description">
+        <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
+        <textarea name="description" cols="40" rows="10" class="tbxforms-textarea" required="required" id="id_description">
 </textarea>
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_textarea/test_no_help_text_errors.html
+++ b/tests/layout/__snapshots__/test_textarea/test_no_help_text_errors.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -14,11 +14,11 @@
     </div>
     <div id="div_id_description"
          class="tbxforms-form-group tbxforms-form-group--error">
-        <label for="id_description" class="tbxforms-label">Description</label>
+        <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
         <span id="id_description_1_error" class="tbxforms-error-message">
             <span class="tbxforms-visually-hidden">Error:</span> Required error message
         </span>
-        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_1_error" class="tbxforms-textarea tbxforms-input--error" id="id_description">
+        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_1_error" class="tbxforms-textarea tbxforms-input--error" required="required" id="id_description">
 </textarea>
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_textarea/test_no_label.html
+++ b/tests/layout/__snapshots__/test_textarea/test_no_label.html
@@ -1,7 +1,7 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_description" class="tbxforms-form-group">
         <span id="id_description_hint" class="tbxforms-hint">Help text</span>
-        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_hint" class="tbxforms-textarea" id="id_description">
+        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_hint" class="tbxforms-textarea" required="required" id="id_description">
 </textarea>
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_textarea/test_show_label_as_heading.html
+++ b/tests/layout/__snapshots__/test_textarea/test_show_label_as_heading.html
@@ -1,10 +1,8 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div id="div_id_description" class="tbxforms-form-group">
-        <h1 class="tbxforms-label-wrapper">
-            <label for="id_description" class="tbxforms-label">Description</label>
-        </h1>
+        <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
         <span id="id_description_hint" class="tbxforms-hint">Help text</span>
-        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_hint" class="tbxforms-textarea" id="id_description">
+        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_hint" class="tbxforms-textarea" required="required" id="id_description">
 </textarea>
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_textarea/test_show_label_as_heading.html
+++ b/tests/layout/__snapshots__/test_textarea/test_show_label_as_heading.html
@@ -1,6 +1,8 @@
 <form class="tbxforms" method="post">
     <div id="div_id_description" class="tbxforms-form-group">
-        <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
+        <h1 class="tbxforms-label-wrapper">
+            <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
+        </h1>
         <span id="id_description_hint" class="tbxforms-hint">Help text</span>
         <textarea name="description" cols="40" rows="10" aria-describedby="id_description_hint" class="tbxforms-textarea" required="required" id="id_description">
 </textarea>

--- a/tests/layout/__snapshots__/test_textarea/test_threshold.html
+++ b/tests/layout/__snapshots__/test_textarea/test_threshold.html
@@ -2,7 +2,7 @@
     <div id="div_id_description" class="tbxforms-form-group">
         <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
         <span id="id_description_hint" class="tbxforms-hint">Help text</span>
-        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_hint" class="tbxforms-textarea" required="required" id="id_description">
+        <textarea name="description" cols="40" rows="10" max-words="100" threshold="50" aria-describedby="id_description_hint" class="tbxforms-textarea" required="required" id="id_description">
 Field value</textarea>
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_textarea/test_threshold.html
+++ b/tests/layout/__snapshots__/test_textarea/test_threshold.html
@@ -1,16 +1,8 @@
-<form method="post">
-    <div class="tbxforms-character-count"
-         data-module="tbxforms-character-count"
-         data-maxwords="100"
-         data-threshold="50">
-        <div id="div_id_description" class="tbxforms-form-group">
-            <label for="id_description" class="tbxforms-label">Description</label>
-            <span id="id_description_hint" class="tbxforms-hint">Help text</span>
-            <textarea name="description" cols="40" rows="10" class="tbxforms-textarea tbxforms-js-character-count" aria-describedby="id_description_hint id_description-info" id="id_description">
+<form class="tbxforms" method="post">
+    <div id="div_id_description" class="tbxforms-form-group">
+        <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
+        <span id="id_description_hint" class="tbxforms-hint">Help text</span>
+        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_hint" class="tbxforms-textarea" required="required" id="id_description">
 Field value</textarea>
-            <span id="id_description-info"
-                  class="tbxforms-hint tbxforms-character-count__message"
-                  aria-live="polite">You can enter up to 100 words</span>
-        </div>
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_textarea/test_threshold.html
+++ b/tests/layout/__snapshots__/test_textarea/test_threshold.html
@@ -1,8 +1,16 @@
 <form class="tbxforms" method="post">
-    <div id="div_id_description" class="tbxforms-form-group">
-        <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
-        <span id="id_description_hint" class="tbxforms-hint">Help text</span>
-        <textarea name="description" cols="40" rows="10" max-words="100" threshold="50" aria-describedby="id_description_hint" class="tbxforms-textarea" required="required" id="id_description">
+    <div class="tbxforms-character-count"
+         data-module="tbxforms-character-count"
+         data-maxwords="100"
+         data-threshold="50">
+        <div id="div_id_description" class="tbxforms-form-group">
+            <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
+            <span id="id_description_hint" class="tbxforms-hint">Help text</span>
+            <textarea name="description" cols="40" rows="10" class="tbxforms-textarea tbxforms-js-character-count" aria-describedby="id_description_hint id_description-info" required="required" id="id_description">
 Field value</textarea>
+            <span id="id_description-info"
+                  class="tbxforms-hint tbxforms-character-count__message"
+                  aria-live="polite">You can enter up to 100 words</span>
+        </div>
     </div>
 </form>

--- a/tests/layout/__snapshots__/test_textarea/test_validation_error_attributes.html
+++ b/tests/layout/__snapshots__/test_textarea/test_validation_error_attributes.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form class="tbxforms" method="post">
     <div class="tbxforms-error-summary"
          aria-labelledby="error-summary-title"
          role="alert"
@@ -14,12 +14,12 @@
     </div>
     <div id="div_id_description"
          class="tbxforms-form-group tbxforms-form-group--error">
-        <label for="id_description" class="tbxforms-label">Description</label>
+        <label for="id_description" class="tbxforms-label tbxforms-label--m">Description</label>
         <span id="id_description_1_error" class="tbxforms-error-message">
             <span class="tbxforms-visually-hidden">Error:</span> Required error message
         </span>
         <span id="id_description_hint" class="tbxforms-hint">Help text</span>
-        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_1_error id_description_hint" class="tbxforms-textarea tbxforms-input--error" id="id_description">
+        <textarea name="description" cols="40" rows="10" aria-describedby="id_description_1_error id_description_hint" class="tbxforms-textarea tbxforms-input--error" required="required" id="id_description">
 </textarea>
     </div>
 </form>

--- a/tests/layout/test_checkbox.py
+++ b/tests/layout/test_checkbox.py
@@ -2,7 +2,6 @@
 Tests to verify a single (boolean) checkbox is rendered correctly.
 
 """
-from tbxforms.helper import FormHelper
 from tbxforms.layout import (
     Field,
     Layout,
@@ -27,7 +26,6 @@ def test_validation_error_attributes(snapshot_html):
 def test_checkbox_size(snapshot_html):
     """Verify size of the checkbox can be changed from the default."""
     form = CheckboxForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("accept", context={"checkboxes_small": True})
     )

--- a/tests/layout/test_checkbox.py
+++ b/tests/layout/test_checkbox.py
@@ -1,7 +1,7 @@
 """
 Tests to verify a single (boolean) checkbox is rendered correctly.
-
 """
+
 from tbxforms.layout import (
     Field,
     Layout,
@@ -26,9 +26,7 @@ def test_validation_error_attributes(snapshot_html):
 def test_checkbox_size(snapshot_html):
     """Verify size of the checkbox can be changed from the default."""
     form = CheckboxForm()
-    form.helper.layout = Layout(
-        Field("accept", context={"checkboxes_small": True})
-    )
+    form.helper.layout = Layout(Field.checkbox("accept", small=True))
     assert render_form(form) == snapshot_html
 
 

--- a/tests/layout/test_checkboxes.py
+++ b/tests/layout/test_checkboxes.py
@@ -2,7 +2,6 @@
 Tests to verify checkboxes are rendered correctly.
 
 """
-from tbxforms.helper import FormHelper
 from tbxforms.layout import (
     Field,
     Layout,
@@ -18,7 +17,6 @@ from tests.utils import render_form
 def test_initial_attributes(snapshot_html):
     """Verify all the gds attributes are displayed."""
     form = CheckboxesForm(initial={"method": ["email", "text"]})
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field.checkboxes("method"))
     assert render_form(form) == snapshot_html
 
@@ -33,7 +31,6 @@ def test_validation_error_attributes(snapshot_html):
 def test_choices(snapshot_html):
     """Verify that hints are displayed."""
     form = CheckboxesChoiceForm(initial={"method": ["email", "text"]})
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field.checkboxes("method"))
     assert render_form(form) == snapshot_html
 
@@ -41,7 +38,6 @@ def test_choices(snapshot_html):
 def test_checkbox_size(snapshot_html):
     """Verify size of the checkbox can be changed from the default."""
     form = CheckboxesForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("method", context={"checkboxes_small": True})
     )
@@ -51,7 +47,6 @@ def test_checkbox_size(snapshot_html):
 def test_show_legend_as_heading(snapshot_html):
     """Verify the field legend can be displayed as the page heading."""
     form = CheckboxesForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field("method", context={"legend_tag": "h1"}))
     assert render_form(form) == snapshot_html
 
@@ -59,7 +54,6 @@ def test_show_legend_as_heading(snapshot_html):
 def test_change_legend_size(snapshot_html):
     """Verify size of the field legend can be changed from the default."""
     form = CheckboxesForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("method", context={"legend_size": Size.for_legend("l")})
     )

--- a/tests/layout/test_checkboxes.py
+++ b/tests/layout/test_checkboxes.py
@@ -36,16 +36,14 @@ def test_choices(snapshot_html):
 def test_checkbox_size(snapshot_html):
     """Verify size of the checkbox can be changed from the default."""
     form = CheckboxesForm()
-    form.helper.layout = Layout(
-        Field("method", context={"checkboxes_small": True})
-    )
+    form.helper.layout = Layout(Field.checkboxes("method", small=True))
     assert render_form(form) == snapshot_html
 
 
 def test_show_legend_as_heading(snapshot_html):
     """Verify the field legend can be displayed as the page heading."""
     form = CheckboxesForm()
-    form.helper.layout = Layout(Field("method", context={"legend_tag": "h1"}))
+    form.helper.layout = Layout(Field.checkboxes("method", legend_tag="h1"))
     assert render_form(form) == snapshot_html
 
 
@@ -53,7 +51,7 @@ def test_change_legend_size(snapshot_html):
     """Verify size of the field legend can be changed from the default."""
     form = CheckboxesForm()
     form.helper.layout = Layout(
-        Field("method", context={"legend_size": Size.for_legend("l")})
+        Field.checkboxes("method", legend_size=Size.LARGE)
     )
     assert render_form(form) == snapshot_html
 

--- a/tests/layout/test_checkboxes.py
+++ b/tests/layout/test_checkboxes.py
@@ -17,7 +17,6 @@ from tests.utils import render_form
 def test_initial_attributes(snapshot_html):
     """Verify all the gds attributes are displayed."""
     form = CheckboxesForm(initial={"method": ["email", "text"]})
-    form.helper.layout = Layout(Field.checkboxes("method"))
     assert render_form(form) == snapshot_html
 
 
@@ -31,7 +30,6 @@ def test_validation_error_attributes(snapshot_html):
 def test_choices(snapshot_html):
     """Verify that hints are displayed."""
     form = CheckboxesChoiceForm(initial={"method": ["email", "text"]})
-    form.helper.layout = Layout(Field.checkboxes("method"))
     assert render_form(form) == snapshot_html
 
 

--- a/tests/layout/test_fieldset.py
+++ b/tests/layout/test_fieldset.py
@@ -37,14 +37,14 @@ def test_change_legend_size(snapshot_html):
 def test_css_class(snapshot_html):
     """Verify an extra CSS class can be added to the fieldset."""
     form = FieldsetForm()
-    form.helper.layout = Layout(Fieldset(css_class="extra-css-class"))
+    form.helper[0].update_attributes(css_class="extra-css-class")
     assert render_form(form) == snapshot_html
 
 
 def test_css_id(snapshot_html):
     """Verify the id attribute can be set on the fieldset."""
     form = FieldsetForm()
-    form.helper.layout = Layout(Fieldset(css_id="new_id"))
+    form.helper[0].update_attributes(css_id="new_id")
     assert render_form(form) == snapshot_html
 
 

--- a/tests/layout/test_fieldset.py
+++ b/tests/layout/test_fieldset.py
@@ -1,11 +1,7 @@
 """
 Tests to verify fieldsets are rendered correctly.
 """
-from tbxforms.layout import (
-    Fieldset,
-    Layout,
-    Size,
-)
+from tbxforms.layout import Size
 from tests.forms import FieldsetForm
 from tests.utils import render_form
 
@@ -19,18 +15,14 @@ def test_basic_layout(snapshot_html):
 def test_show_legend_as_heading(snapshot_html):
     """Verify the field legend can be displayed as the page heading."""
     form = FieldsetForm()
-    form.helper.layout = Layout(
-        Fieldset("name", "email", legend="Contact", legend_tag="h1")
-    )
+    form.helper[0].update_attributes(legend_tag="h1")
     assert render_form(form) == snapshot_html
 
 
 def test_change_legend_size(snapshot_html):
     """Verify size of the field legend can be changed from the default."""
     form = FieldsetForm()
-    form.helper.layout = Layout(
-        Fieldset("name", "email", legend="Contact", legend_size=Size.LARGE)
-    )
+    form.helper[0].update_attributes(legend_size=Size.LARGE)
     assert render_form(form) == snapshot_html
 
 
@@ -51,5 +43,5 @@ def test_css_id(snapshot_html):
 def test_attribute(snapshot_html):
     """Verify the extra attributes can be added."""
     form = FieldsetForm()
-    form.helper.layout = Layout(Fieldset(key="value"))
+    form.helper[0].update_attributes(key="value")
     assert render_form(form) == snapshot_html

--- a/tests/layout/test_fieldset.py
+++ b/tests/layout/test_fieldset.py
@@ -1,7 +1,6 @@
 """
 Tests to verify fieldsets are rendered correctly.
 """
-from tbxforms.helper import FormHelper
 from tbxforms.layout import (
     Fieldset,
     Layout,
@@ -20,7 +19,6 @@ def test_basic_layout(snapshot_html):
 def test_show_legend_as_heading(snapshot_html):
     """Verify the field legend can be displayed as the page heading."""
     form = FieldsetForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Fieldset("name", "email", legend="Contact", legend_tag="h1")
     )
@@ -30,7 +28,6 @@ def test_show_legend_as_heading(snapshot_html):
 def test_change_legend_size(snapshot_html):
     """Verify size of the field legend can be changed from the default."""
     form = FieldsetForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Fieldset("name", "email", legend="Contact", legend_size=Size.LARGE)
     )
@@ -40,7 +37,6 @@ def test_change_legend_size(snapshot_html):
 def test_css_class(snapshot_html):
     """Verify an extra CSS class can be added to the fieldset."""
     form = FieldsetForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Fieldset(css_class="extra-css-class"))
     assert render_form(form) == snapshot_html
 
@@ -48,7 +44,6 @@ def test_css_class(snapshot_html):
 def test_css_id(snapshot_html):
     """Verify the id attribute can be set on the fieldset."""
     form = FieldsetForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Fieldset(css_id="new_id"))
     assert render_form(form) == snapshot_html
 
@@ -56,6 +51,5 @@ def test_css_id(snapshot_html):
 def test_attribute(snapshot_html):
     """Verify the extra attributes can be added."""
     form = FieldsetForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Fieldset(key="value"))
     assert render_form(form) == snapshot_html

--- a/tests/layout/test_file_upload.py
+++ b/tests/layout/test_file_upload.py
@@ -2,7 +2,6 @@
 Tests to verify file uploads are rendered correctly.
 
 """
-from tbxforms.helper import FormHelper
 from tbxforms.layout import (
     Field,
     Layout,
@@ -28,7 +27,6 @@ def test_validation_error_attributes(snapshot_html):
 def test_show_label_as_heading(snapshot_html):
     """Verify the field label can be displayed as the page heading."""
     form = FileUploadForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field("file", context={"label_tag": "h1"}))
     assert render_form(form) == snapshot_html
 
@@ -36,7 +34,6 @@ def test_show_label_as_heading(snapshot_html):
 def test_change_label_size(snapshot_html):
     """Verify size of the field label can be changed from the default."""
     form = FileUploadForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("file", context={"label_size": Size.for_label("l")})
     )

--- a/tests/layout/test_file_upload.py
+++ b/tests/layout/test_file_upload.py
@@ -35,7 +35,7 @@ def test_change_label_size(snapshot_html):
     """Verify size of the field label can be changed from the default."""
     form = FileUploadForm()
     form.helper.layout = Layout(
-        Field("file", context={"label_size": Size.for_label("l")})
+        Field("file", context={"label_size": Size.LARGE})
     )
     assert render_form(form) == snapshot_html
 

--- a/tests/layout/test_radios.py
+++ b/tests/layout/test_radios.py
@@ -36,34 +36,28 @@ def test_choices(snapshot_html):
 def test_small(snapshot_html):
     """Verify size of the radio buttons can be changed."""
     form = RadiosForm()
-    form.helper.layout = Layout(
-        Field("method", context={"radios_small": True})
-    )
+    form.helper.layout = Layout(Field.radios("method", small=True))
     assert render_form(form) == snapshot_html
 
 
 def test_inline(snapshot_html):
     """Verify radio buttons can be displayed in a row."""
     form = RadiosForm()
-    form.helper.layout = Layout(
-        Field("method", context={"radios_inline": True})
-    )
+    form.helper.layout = Layout(Field.radios("method", inline=True))
     assert render_form(form) == snapshot_html
 
 
 def test_show_legend_as_heading(snapshot_html):
     """Verify the field legend can be displayed as the page heading."""
     form = RadiosForm()
-    form.helper.layout = Layout(Field("method", context={"legend_tag": "h1"}))
+    form.helper.layout = Layout(Field.radios("method", legend_tag="h1"))
     assert render_form(form) == snapshot_html
 
 
 def test_change_legend_size(snapshot_html):
     """Verify size of the field legend can be changed from the default."""
     form = RadiosForm()
-    form.helper.layout = Layout(
-        Field("method", context={"legend_size": Size.for_legend("l")})
-    )
+    form.helper.layout = Layout(Field.radios("method", legend_size=Size.LARGE))
     assert render_form(form) == snapshot_html
 
 

--- a/tests/layout/test_radios.py
+++ b/tests/layout/test_radios.py
@@ -17,7 +17,6 @@ from tests.utils import render_form
 def test_initial_attributes(snapshot_html):
     """Verify all the gds attributes are displayed."""
     form = RadiosForm(initial={"method": "email"})
-    form.helper.layout = Layout(Field.radios("method"))
     assert render_form(form) == snapshot_html
 
 
@@ -31,7 +30,6 @@ def test_validation_error_attributes(snapshot_html):
 def test_choices(snapshot_html):
     """Verify hints and dividers are displayed."""
     form = RadiosChoiceForm(initial={"method": "email"})
-    form.helper.layout = Layout(Field.radios("method"))
     assert render_form(form) == snapshot_html
 
 

--- a/tests/layout/test_radios.py
+++ b/tests/layout/test_radios.py
@@ -2,7 +2,6 @@
 Tests to verify radio buttons are rendered correctly.
 
 """
-from tbxforms.helper import FormHelper
 from tbxforms.layout import (
     Field,
     Layout,
@@ -18,7 +17,6 @@ from tests.utils import render_form
 def test_initial_attributes(snapshot_html):
     """Verify all the gds attributes are displayed."""
     form = RadiosForm(initial={"method": "email"})
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field.radios("method"))
     assert render_form(form) == snapshot_html
 
@@ -33,7 +31,6 @@ def test_validation_error_attributes(snapshot_html):
 def test_choices(snapshot_html):
     """Verify hints and dividers are displayed."""
     form = RadiosChoiceForm(initial={"method": "email"})
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field.radios("method"))
     assert render_form(form) == snapshot_html
 
@@ -41,7 +38,6 @@ def test_choices(snapshot_html):
 def test_small(snapshot_html):
     """Verify size of the radio buttons can be changed."""
     form = RadiosForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("method", context={"radios_small": True})
     )
@@ -51,7 +47,6 @@ def test_small(snapshot_html):
 def test_inline(snapshot_html):
     """Verify radio buttons can be displayed in a row."""
     form = RadiosForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("method", context={"radios_inline": True})
     )
@@ -61,7 +56,6 @@ def test_inline(snapshot_html):
 def test_show_legend_as_heading(snapshot_html):
     """Verify the field legend can be displayed as the page heading."""
     form = RadiosForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field("method", context={"legend_tag": "h1"}))
     assert render_form(form) == snapshot_html
 
@@ -69,7 +63,6 @@ def test_show_legend_as_heading(snapshot_html):
 def test_change_legend_size(snapshot_html):
     """Verify size of the field legend can be changed from the default."""
     form = RadiosForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("method", context={"legend_size": Size.for_legend("l")})
     )

--- a/tests/layout/test_select.py
+++ b/tests/layout/test_select.py
@@ -27,16 +27,14 @@ def test_validation_error_attributes(snapshot_html):
 def test_show_label_as_heading(snapshot_html):
     """Verify the field label can be displayed as the page heading."""
     form = SelectForm()
-    form.helper.layout = Layout(Field("method", context={"label_tag": "h1"}))
+    form.helper.layout = Layout(Field.select("method", label_tag="h1"))
     assert render_form(form) == snapshot_html
 
 
 def test_change_label_size(snapshot_html):
     """Verify size of the field label can be changed from the default."""
     form = SelectForm()
-    form.helper.layout = Layout(
-        Field("method", context={"label_size": Size.for_label("l")})
-    )
+    form.helper.layout = Layout(Field.select("method", label_size=Size.LARGE))
     assert render_form(form) == snapshot_html
 
 

--- a/tests/layout/test_select.py
+++ b/tests/layout/test_select.py
@@ -2,7 +2,6 @@
 Tests to verify selects are rendered correctly.
 
 """
-from tbxforms.helper import FormHelper
 from tbxforms.layout import (
     Field,
     Layout,
@@ -28,7 +27,6 @@ def test_validation_error_attributes(snapshot_html):
 def test_show_label_as_heading(snapshot_html):
     """Verify the field label can be displayed as the page heading."""
     form = SelectForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field("method", context={"label_tag": "h1"}))
     assert render_form(form) == snapshot_html
 
@@ -36,7 +34,6 @@ def test_show_label_as_heading(snapshot_html):
 def test_change_label_size(snapshot_html):
     """Verify size of the field label can be changed from the default."""
     form = SelectForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("method", context={"label_size": Size.for_label("l")})
     )

--- a/tests/layout/test_text_input.py
+++ b/tests/layout/test_text_input.py
@@ -2,7 +2,6 @@
 Tests to verify text fields are rendered correctly.
 
 """
-from tbxforms.helper import FormHelper
 from tbxforms.layout import (
     Field,
     Layout,
@@ -28,7 +27,6 @@ def test_validation_error_attributes(snapshot_html):
 def test_show_label_as_heading(snapshot_html):
     """Verify the field label can be displayed as the page heading."""
     form = TextInputForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field("name", context={"label_tag": "h1"}))
     assert render_form(form) == snapshot_html
 
@@ -36,7 +34,6 @@ def test_show_label_as_heading(snapshot_html):
 def test_change_label_size(snapshot_html):
     """Verify size of the field label can be changed from the default."""
     form = TextInputForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("name", context={"label_size": Size.for_label("l")})
     )

--- a/tests/layout/test_text_input.py
+++ b/tests/layout/test_text_input.py
@@ -27,16 +27,14 @@ def test_validation_error_attributes(snapshot_html):
 def test_show_label_as_heading(snapshot_html):
     """Verify the field label can be displayed as the page heading."""
     form = TextInputForm()
-    form.helper.layout = Layout(Field("name", context={"label_tag": "h1"}))
+    form.helper.layout = Layout(Field.text("name", label_tag="h1"))
     assert render_form(form) == snapshot_html
 
 
 def test_change_label_size(snapshot_html):
     """Verify size of the field label can be changed from the default."""
     form = TextInputForm()
-    form.helper.layout = Layout(
-        Field("name", context={"label_size": Size.for_label("l")})
-    )
+    form.helper.layout = Layout(Field.text("name", label_size=Size.LARGE))
     assert render_form(form) == snapshot_html
 
 

--- a/tests/layout/test_textarea.py
+++ b/tests/layout/test_textarea.py
@@ -3,7 +3,6 @@ Tests to verify textareas are rendered correctly.
 """
 import pytest
 
-from tbxforms.helper import FormHelper
 from tbxforms.layout import (
     Field,
     Layout,
@@ -29,7 +28,6 @@ def test_validation_error_attributes(snapshot_html):
 def test_show_label_as_heading(snapshot_html):
     """Verify the field label can be displayed as the page heading."""
     form = TextareaForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("description", context={"label_tag": "h1"})
     )
@@ -39,7 +37,6 @@ def test_show_label_as_heading(snapshot_html):
 def test_change_label_size(snapshot_html):
     """Verify size of the field label can be changed from the default."""
     form = TextareaForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field("description", context={"label_size": Size.for_label("l")})
     )
@@ -72,7 +69,6 @@ def test_no_help_text_errors(snapshot_html):
 def test_character_count(snapshot_html):
     """Verify the field can show the maximum number of characters allowed."""
     form = TextareaForm(initial={"description": "Field value"})
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field.textarea("description", max_characters=100)
     )
@@ -92,7 +88,6 @@ def test_threshold(snapshot_html):
     Verify info is shown after a certain number of words has been entered.
     """
     form = TextareaForm(initial={"description": "Field value"})
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         Field.textarea("description", max_words=100, threshold=50)
     )

--- a/tests/layout/test_textarea.py
+++ b/tests/layout/test_textarea.py
@@ -69,9 +69,7 @@ def test_no_help_text_errors(snapshot_html):
 def test_character_count(snapshot_html):
     """Verify the field can show the maximum number of characters allowed."""
     form = TextareaForm(initial={"description": "Field value"})
-    form.helper.layout = Layout(
-        Field.textarea("description", max_characters=100)
-    )
+    form.helper.layout = Layout(Field("description", max_characters=100))
     assert render_form(form) == snapshot_html
 
 
@@ -89,7 +87,7 @@ def test_threshold(snapshot_html):
     """
     form = TextareaForm(initial={"description": "Field value"})
     form.helper.layout = Layout(
-        Field.textarea("description", max_words=100, threshold=50)
+        Field("description", max_words=100, threshold=50)
     )
     assert render_form(form) == snapshot_html
 

--- a/tests/layout/test_textarea.py
+++ b/tests/layout/test_textarea.py
@@ -28,9 +28,7 @@ def test_validation_error_attributes(snapshot_html):
 def test_show_label_as_heading(snapshot_html):
     """Verify the field label can be displayed as the page heading."""
     form = TextareaForm()
-    form.helper.layout = Layout(
-        Field("description", context={"label_tag": "h1"})
-    )
+    form.helper.layout = Layout(Field.textarea("description", label_tag="h1"))
     assert render_form(form) == snapshot_html
 
 
@@ -38,7 +36,7 @@ def test_change_label_size(snapshot_html):
     """Verify size of the field label can be changed from the default."""
     form = TextareaForm()
     form.helper.layout = Layout(
-        Field("description", context={"label_size": Size.for_label("l")})
+        Field.textarea("description", label_size=Size.LARGE)
     )
     assert render_form(form) == snapshot_html
 
@@ -69,7 +67,9 @@ def test_no_help_text_errors(snapshot_html):
 def test_character_count(snapshot_html):
     """Verify the field can show the maximum number of characters allowed."""
     form = TextareaForm(initial={"description": "Field value"})
-    form.helper.layout = Layout(Field("description", max_characters=100))
+    form.helper.layout = Layout(
+        Field.textarea("description", max_characters=100)
+    )
     assert render_form(form) == snapshot_html
 
 
@@ -87,7 +87,7 @@ def test_threshold(snapshot_html):
     """
     form = TextareaForm(initial={"description": "Field value"})
     form.helper.layout = Layout(
-        Field("description", max_words=100, threshold=50)
+        Field.textarea("description", max_words=100, threshold=50)
     )
     assert render_form(form) == snapshot_html
 


### PR DESCRIPTION
Resolves https://github.com/torchbox/tbxforms/issues/44

* Re-uses our `BaseForm` within tests as opposed to testing arbitrary forms
* Allows changes to a form's helper after instantiation
* Fixes overriding the label size and tag for `Field.select()`
* Update README to be clearer
* Renames `BaseForm` to `TbxFormsMixin` to more accurately convey what it is