### PR TITLE
Use `math.div` over literal `/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ variables can be customised.
 -   Django `>=2.2`
 -   django-crispy-forms `>=1.13.0,<2.0`
 -   wagtail `>=2.15` if using `WagtailBaseForm`
+-   sass `>=1.33.0` if building the sass yourself
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,11 @@
         "autoprefixer": "^10.2.5",
         "eslint": "^7.26.0",
         "prettier": "^2.3.2",
-        "sass": "^1.26.5",
+        "sass": "^1.69.7",
         "vite": "^2.2.3"
+      },
+      "peerDependencies": {
+        "sass": ">=1.33.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -872,6 +875,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
+      "dev": true
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "dev": true,
@@ -1296,17 +1305,20 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.26.5",
+      "version": "1.69.7",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.7.tgz",
+      "integrity": "sha512-rzj2soDeZ8wtE2egyLXgOOHQvaC2iosZrkF6v3EUG+tBwEvhqUCzm0VP3k9gHF9LXbSrRhT5SksoI56Iw8NPnQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "chokidar": ">=2.0.0 <4.0.0"
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
         "sass": "sass.js"
       },
       "engines": {
-        "node": ">=8.9.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/semver": {
@@ -2122,6 +2134,12 @@
       "version": "4.0.6",
       "dev": true
     },
+    "immutable": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
+      "dev": true
+    },
     "import-fresh": {
       "version": "3.3.0",
       "dev": true,
@@ -2375,10 +2393,14 @@
       }
     },
     "sass": {
-      "version": "1.26.5",
+      "version": "1.69.7",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.7.tgz",
+      "integrity": "sha512-rzj2soDeZ8wtE2egyLXgOOHQvaC2iosZrkF6v3EUG+tBwEvhqUCzm0VP3k9gHF9LXbSrRhT5SksoI56Iw8NPnQ==",
       "dev": true,
       "requires": {
-        "chokidar": ">=2.0.0 <4.0.0"
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "autoprefixer": "^10.2.5",
     "eslint": "^7.26.0",
     "prettier": "^2.3.2",
-    "sass": "^1.26.5",
+    "sass": "^1.69.7",
     "vite": "^2.2.3"
   },
   "scripts": {

--- a/tbxforms/static/sass/abstracts/_variables.scss
+++ b/tbxforms/static/sass/abstracts/_variables.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 // --------------------------------- Colors ------------------------------------
 
 $tbxforms-error-colour: #d4351c !default;
@@ -35,7 +37,7 @@ $tbxforms-weight--normal: 400 !default;
 
 $tbxforms-grid: 20px !default;
 $tbxforms-spacer: $tbxforms-grid !default;
-$tbxforms-in-field-spacer: ($tbxforms-grid / 2) !default;
+$tbxforms-in-field-spacer: math.div($tbxforms-grid, 2) !default;
 $tbxforms-form-group-spacer: ($tbxforms-grid * 1.5) !default;
 
 $tbxforms-border-width: 4px !default;

--- a/tbxforms/static/sass/components/_checkboxes.scss
+++ b/tbxforms/static/sass/components/_checkboxes.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .tbxforms-checkboxes__item {
     @include tbxforms-font($size: 'default');
 
@@ -18,7 +20,10 @@
 }
 
 .tbxforms-checkboxes__input {
-    $input-offset: ($tbxforms-touch-target-size - $tbxforms-checkboxes-size) / 2;
+    $input-offset: math.div(
+        $tbxforms-touch-target-size - $tbxforms-checkboxes-size,
+        2
+    );
 
     cursor: pointer;
 
@@ -136,8 +141,9 @@
 // =========================================================
 
 .tbxforms-checkboxes--small {
-    $input-offset: (
-        ($tbxforms-touch-target-size - $tbxforms-small-checkboxes-size) / 2
+    $input-offset: math.div(
+        $tbxforms-touch-target-size - $tbxforms-small-checkboxes-size,
+        2
     );
     $label-offset: $tbxforms-touch-target-size - $input-offset;
 

--- a/tbxforms/static/sass/components/_radios.scss
+++ b/tbxforms/static/sass/components/_radios.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .tbxforms-radios__item {
     @include tbxforms-font($size: 'default');
 
@@ -18,7 +20,10 @@
 }
 
 .tbxforms-radios__input {
-    $input-offset: ($tbxforms-touch-target-size - $tbxforms-radios-size) / 2;
+    $input-offset: math.div(
+        $tbxforms-touch-target-size - $tbxforms-radios-size,
+        2
+    );
 
     cursor: pointer;
 
@@ -144,8 +149,10 @@
 // =========================================================
 
 .tbxforms-radios--small {
-    $input-offset: ($tbxforms-touch-target-size - $tbxforms-small-radios-size) /
-        2;
+    $input-offset: math.div(
+        $tbxforms-touch-target-size - $tbxforms-small-radios-size,
+        2
+    );
     $label-offset: $tbxforms-touch-target-size - $input-offset;
 
     .tbxforms-radios__item {

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,4 +9,11 @@ module.exports = defineConfig({
       fileName: (format) => `tbxforms.${format}.js`,
     },
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        fatalDeprecation: true,
+      },
+    },
+  },
 });


### PR DESCRIPTION
Using a literal `/` as a division operator is deprecated, and raises warnings on versions of Sass over 1.33.0: https://sass-lang.com/documentation/breaking-changes/slash-div/

This adds a dependency on `sass` over 1.33.0 (released May 2021), as the `sass:math` module didn't exist before then.