### PR TITLE
Fix issue of hints not showing up on django 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Fixed
+
+-   Choice hints not showing on Django 5.x [#69]
+
 ## [2.0.1](https://github.com/torchbox/tbxforms/releases/tag/v2.0.1)
 
 ### Pinned packages updated

--- a/tbxforms/choices.py
+++ b/tbxforms/choices.py
@@ -10,7 +10,7 @@ Examples: ::
 
     METHODS = (
         Choice("email", "Email"),
-        Choice("phone", "Phone", hint="Select this only if you have a mobile phone"),  # noqa
+        Choice("phone", "Phone", hint="Select this only if you have a phone."),
         Choice("text", "Text message"),
     )
 
@@ -27,9 +27,9 @@ Args:
 
     label (str): the label for the checkbox or radio button.
 
-    **kwargs: additional attributes to display for the checkbox or radio button.
-        Two attributes are supported: a `hint` that is displayed below the label
-        and a 'divider' that is displayed after the radio button.
+    **kwargs: additional attributes to display for the checkbox / radio button.
+        Two attributes are supported: a `hint` that is displayed below the
+        label and a 'divider' that is displayed after the radio button.
 """
 
 if DJANGO_VERSION < (5, 0):

--- a/tbxforms/choices.py
+++ b/tbxforms/choices.py
@@ -1,4 +1,4 @@
-import django
+from django import VERSION as DJANGO_VERSION
 
 """
 Choice is used for the items in the choices attribute of a form field.
@@ -30,39 +30,33 @@ Args:
     **kwargs: additional attributes to display for the checkbox or radio button.
         Two attributes are supported: a `hint` that is displayed below the label
         and a 'divider' that is displayed after the radio button.
-
 """
 
-# Django 5+ internals changed the way the choices on a ChoiceField are
-# normalised. Changing the parent class to a Promise preserves the hint
-# and divider attributes so the field can be rendered.
+if DJANGO_VERSION < (5, 0):
 
-if django.VERSION[0] < 5:
-
-    class Choice:
-        def __init__(self, value, label, **kwargs):
-            self.value = value
-            self.label = label
-            for key, value in kwargs.items():
-                setattr(self, key, value)
-
-        def __iter__(self):
-            return iter((self.value, self.label))
-
-        def __getitem__(self, index):
-            return (self.value, self.label)[index]
+    class BaseChoice:
+        pass
 
 else:
+    from django.utils import functional
 
-    class Choice(django.utils.functional.Promise):
-        def __init__(self, value, label, **kwargs):
-            self.value = value
-            self.label = label
-            for key, value in kwargs.items():
-                setattr(self, key, value)
+    # Django 5+ internals changed the way the choices on a ChoiceField are
+    # normalised. Changing the parent class to a Promise preserves the hint
+    # and divider attributes so the field can be rendered.
 
-        def __iter__(self):
-            return iter((self.value, self.label))
+    class BaseChoice(functional.Promise):
+        pass
 
-        def __getitem__(self, index):
-            return (self.value, self.label)[index]
+
+class Choice(BaseChoice):
+    def __init__(self, value, label, **kwargs):
+        self.value = value
+        self.label = label
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def __iter__(self):
+        return iter((self.value, self.label))
+
+    def __getitem__(self, index):
+        return (self.value, self.label)[index]

--- a/tbxforms/choices.py
+++ b/tbxforms/choices.py
@@ -1,45 +1,68 @@
-class Choice:
-    """
-    Choice is used for the items in the choices attribute of a form field.
+import django
 
-    It emulates the tuple that returns the field value and the label and
-    supports the attributes needed to display hints and dividers.
+"""
+Choice is used for the items in the choices attribute of a form field.
 
-    Examples: ::
+It emulates the tuple that returns the field value and the label and
+supports the attributes needed to display hints and dividers.
 
-        METHODS = (
-            Choice("email", "Email"),
-            Choice("phone", "Phone", hint="Select this only if you have a mobile phone"),  # noqa
-            Choice("text", "Text message"),
-        )
+Examples: ::
 
-        method = forms.MultipleChoiceField(
-            choices=METHODS,
-            widget=forms.CheckboxSelectMultiple,
-            label="How would you like to be contacted?",
-            help_text="Select all options that are relevant to you.",
-            error_messages={"required": "Enter the ways to contact you"},
-        )
+    METHODS = (
+        Choice("email", "Email"),
+        Choice("phone", "Phone", hint="Select this only if you have a mobile phone"),  # noqa
+        Choice("text", "Text message"),
+    )
 
-    Args:
-        value (int, str): the value for the checkbox or radio button.
+    method = forms.MultipleChoiceField(
+        choices=METHODS,
+        widget=forms.CheckboxSelectMultiple,
+        label="How would you like to be contacted?",
+        help_text="Select all options that are relevant to you.",
+        error_messages={"required": "Enter the ways to contact you"},
+    )
 
-        label (str): the label for the checkbox or radio button.
+Args:
+    value (int, str): the value for the checkbox or radio button.
 
-        **kwargs: additional attributes to display for the checkbox or radio button.
-            Two attributes are supported: a `hint` that is displayed below the label
-            and a 'divider' that is displayed after the radio button.
+    label (str): the label for the checkbox or radio button.
 
-    """
+    **kwargs: additional attributes to display for the checkbox or radio button.
+        Two attributes are supported: a `hint` that is displayed below the label
+        and a 'divider' that is displayed after the radio button.
 
-    def __init__(self, value, label, **kwargs):
-        self.value = value
-        self.label = label
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+"""
 
-    def __iter__(self):
-        return iter((self.value, self.label))
+# Django 5+ internals changed the way the choices on a ChoiceField are
+# normalised. Changing the parent class to a Promise preserves the hint
+# and divider attributes so the field can be rendered.
 
-    def __getitem__(self, index):
-        return (self.value, self.label)[index]
+if django.VERSION[0] < 5:
+
+    class Choice:
+        def __init__(self, value, label, **kwargs):
+            self.value = value
+            self.label = label
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+        def __iter__(self):
+            return iter((self.value, self.label))
+
+        def __getitem__(self, index):
+            return (self.value, self.label)[index]
+
+else:
+
+    class Choice(django.utils.functional.Promise):
+        def __init__(self, value, label, **kwargs):
+            self.value = value
+            self.label = label
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+        def __iter__(self):
+            return iter((self.value, self.label))
+
+        def __getitem__(self, index):
+            return (self.value, self.label)[index]

--- a/tbxforms/choices.py
+++ b/tbxforms/choices.py
@@ -38,11 +38,12 @@ if DJANGO_VERSION < (5, 0):
         pass
 
 else:
-    from django.utils import functional
 
     # Django 5+ internals changed the way the choices on a ChoiceField are
     # normalised. Changing the parent class to a Promise preserves the hint
     # and divider attributes so the field can be rendered.
+
+    from django.utils import functional
 
     class BaseChoice(functional.Promise):
         pass


### PR DESCRIPTION
Fixes #66 

This PR fixes the issue of hints not showing for django versions 5.x+, implementing the same solution as in https://github.com/wildfish/crispy-forms-gds/blob/master/src/crispy_forms_gds/choices.py