### PR TITLE
Add required attribute for radio buttons when specified

### DIFF
--- a/tbxforms/templates/tbxforms/layout/radios.html
+++ b/tbxforms/templates/tbxforms/layout/radios.html
@@ -33,6 +33,10 @@
                     id="id_{{ field.html_name }}_{{ forloop.counter }}"
                     value="{{ choice.0|unlocalize }}"
 
+                    {% if field.field.required and forloop.first %}
+                        required
+                    {% endif %}
+
                     {% if choice.0|stringformat:"s" == field.value|stringformat:"s" %}
                         checked="checked"
                     {% endif %}

--- a/tests/layout/__snapshots__/test_conditional_attrs/TestFieldConditionals.test_rendering[radios-checkbox].html
+++ b/tests/layout/__snapshots__/test_conditional_attrs/TestFieldConditionals.test_rendering[radios-checkbox].html
@@ -8,7 +8,8 @@
                            name="trigger_field"
                            class="tbxforms-radios__input"
                            id="id_trigger_field_1"
-                           value="yes" />
+                           value="yes"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label"
                            for="id_trigger_field_1">Yes</label>
                 </div>

--- a/tests/layout/__snapshots__/test_conditional_attrs/TestFieldConditionals.test_rendering[radios-checkboxes].html
+++ b/tests/layout/__snapshots__/test_conditional_attrs/TestFieldConditionals.test_rendering[radios-checkboxes].html
@@ -8,7 +8,8 @@
                            name="trigger_field"
                            class="tbxforms-radios__input"
                            id="id_trigger_field_1"
-                           value="yes" />
+                           value="yes"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label"
                            for="id_trigger_field_1">Yes</label>
                 </div>

--- a/tests/layout/__snapshots__/test_conditional_attrs/TestFieldConditionals.test_rendering[radios-radios].html
+++ b/tests/layout/__snapshots__/test_conditional_attrs/TestFieldConditionals.test_rendering[radios-radios].html
@@ -8,7 +8,8 @@
                            name="trigger_field"
                            class="tbxforms-radios__input"
                            id="id_trigger_field_1"
-                           value="yes" />
+                           value="yes"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label"
                            for="id_trigger_field_1">Yes</label>
                 </div>

--- a/tests/layout/__snapshots__/test_conditional_attrs/TestFieldConditionals.test_rendering[radios-select].html
+++ b/tests/layout/__snapshots__/test_conditional_attrs/TestFieldConditionals.test_rendering[radios-select].html
@@ -8,7 +8,8 @@
                            name="trigger_field"
                            class="tbxforms-radios__input"
                            id="id_trigger_field_1"
-                           value="yes" />
+                           value="yes"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label"
                            for="id_trigger_field_1">Yes</label>
                 </div>

--- a/tests/layout/__snapshots__/test_conditional_attrs/TestFieldConditionals.test_rendering[radios-text].html
+++ b/tests/layout/__snapshots__/test_conditional_attrs/TestFieldConditionals.test_rendering[radios-text].html
@@ -8,7 +8,8 @@
                            name="trigger_field"
                            class="tbxforms-radios__input"
                            id="id_trigger_field_1"
-                           value="yes" />
+                           value="yes"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label"
                            for="id_trigger_field_1">Yes</label>
                 </div>

--- a/tests/layout/__snapshots__/test_conditional_attrs/TestFieldConditionals.test_rendering[radios-textarea].html
+++ b/tests/layout/__snapshots__/test_conditional_attrs/TestFieldConditionals.test_rendering[radios-textarea].html
@@ -8,7 +8,8 @@
                            name="trigger_field"
                            class="tbxforms-radios__input"
                            id="id_trigger_field_1"
-                           value="yes" />
+                           value="yes"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label"
                            for="id_trigger_field_1">Yes</label>
                 </div>

--- a/tests/layout/__snapshots__/test_radios/test_change_legend_size.html
+++ b/tests/layout/__snapshots__/test_radios/test_change_legend_size.html
@@ -9,7 +9,8 @@
                            name="method"
                            class="tbxforms-radios__input"
                            id="id_method_1"
-                           value="email" />
+                           value="email"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label" for="id_method_1">Email</label>
                 </div>
                 <div class="tbxforms-radios__item">

--- a/tests/layout/__snapshots__/test_radios/test_choices.html
+++ b/tests/layout/__snapshots__/test_radios/test_choices.html
@@ -10,6 +10,7 @@
                            class="tbxforms-radios__input"
                            id="id_method_1"
                            value="email"
+                           required
                            checked="checked"
                            aria-describedby="id_method_1_hint" />
                     <label class="tbxforms-label tbxforms-radios__label" for="id_method_1">Email</label>

--- a/tests/layout/__snapshots__/test_radios/test_initial_attributes.html
+++ b/tests/layout/__snapshots__/test_radios/test_initial_attributes.html
@@ -10,6 +10,7 @@
                            class="tbxforms-radios__input"
                            id="id_method_1"
                            value="email"
+                           required
                            checked="checked" />
                     <label class="tbxforms-label tbxforms-radios__label" for="id_method_1">Email</label>
                 </div>

--- a/tests/layout/__snapshots__/test_radios/test_inline.html
+++ b/tests/layout/__snapshots__/test_radios/test_inline.html
@@ -9,7 +9,8 @@
                            name="method"
                            class="tbxforms-radios__input"
                            id="id_method_1"
-                           value="email" />
+                           value="email"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label" for="id_method_1">Email</label>
                 </div>
                 <div class="tbxforms-radios__item">

--- a/tests/layout/__snapshots__/test_radios/test_no_help_text.html
+++ b/tests/layout/__snapshots__/test_radios/test_no_help_text.html
@@ -8,7 +8,8 @@
                            name="method"
                            class="tbxforms-radios__input"
                            id="id_method_1"
-                           value="email" />
+                           value="email"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label" for="id_method_1">Email</label>
                 </div>
                 <div class="tbxforms-radios__item">

--- a/tests/layout/__snapshots__/test_radios/test_no_help_text_errors.html
+++ b/tests/layout/__snapshots__/test_radios/test_no_help_text_errors.html
@@ -26,7 +26,8 @@
                            name="method"
                            class="tbxforms-radios__input"
                            id="id_method_1"
-                           value="email" />
+                           value="email"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label" for="id_method_1">Email</label>
                 </div>
                 <div class="tbxforms-radios__item">

--- a/tests/layout/__snapshots__/test_radios/test_no_legend.html
+++ b/tests/layout/__snapshots__/test_radios/test_no_legend.html
@@ -8,7 +8,8 @@
                            name="method"
                            class="tbxforms-radios__input"
                            id="id_method_1"
-                           value="email" />
+                           value="email"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label" for="id_method_1">Email</label>
                 </div>
                 <div class="tbxforms-radios__item">

--- a/tests/layout/__snapshots__/test_radios/test_required_field_highlighting.html
+++ b/tests/layout/__snapshots__/test_radios/test_required_field_highlighting.html
@@ -12,7 +12,8 @@
                            name="method"
                            class="tbxforms-radios__input"
                            id="id_method_1"
-                           value="email" />
+                           value="email"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label" for="id_method_1">Email</label>
                 </div>
                 <div class="tbxforms-radios__item">

--- a/tests/layout/__snapshots__/test_radios/test_show_legend_as_heading.html
+++ b/tests/layout/__snapshots__/test_radios/test_show_legend_as_heading.html
@@ -11,7 +11,8 @@
                            name="method"
                            class="tbxforms-radios__input"
                            id="id_method_1"
-                           value="email" />
+                           value="email"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label" for="id_method_1">Email</label>
                 </div>
                 <div class="tbxforms-radios__item">

--- a/tests/layout/__snapshots__/test_radios/test_small.html
+++ b/tests/layout/__snapshots__/test_radios/test_small.html
@@ -9,7 +9,8 @@
                            name="method"
                            class="tbxforms-radios__input"
                            id="id_method_1"
-                           value="email" />
+                           value="email"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label" for="id_method_1">Email</label>
                 </div>
                 <div class="tbxforms-radios__item">

--- a/tests/layout/__snapshots__/test_radios/test_validation_error_attributes.html
+++ b/tests/layout/__snapshots__/test_radios/test_validation_error_attributes.html
@@ -28,7 +28,8 @@
                            name="method"
                            class="tbxforms-radios__input"
                            id="id_method_1"
-                           value="email" />
+                           value="email"
+                           required />
                     <label class="tbxforms-label tbxforms-radios__label" for="id_method_1">Email</label>
                 </div>
                 <div class="tbxforms-radios__item">

--- a/tests/layout/test_radios.py
+++ b/tests/layout/test_radios.py
@@ -88,7 +88,8 @@ def test_no_help_text_errors(snapshot_html):
 
 def test_optional_field_highlighting(snapshot_html):
     """
-    Ensure optional fields are marked with "(optional)" by default.
+    Ensure optional fields are marked with "(optional)" by default
+    and ensure it does not render the `required` attribute.
     """
     form = RadiosForm()
     form.fields["method"].required = False


### PR DESCRIPTION
This pull request fixes an issue where radio buttons do not get the `required` attribute even when instantiated with one.